### PR TITLE
Fix pg_dump command

### DIFF
--- a/src/Databases/PostgreSql.php
+++ b/src/Databases/PostgreSql.php
@@ -143,10 +143,10 @@ class PostgreSql extends DbDumper
     public function getDumpCommand($dumpFile)
     {
         $command = [
+            "PGPASSWORD='{$this->password}'",
             "{$this->dumpBinaryPath}pg_dump",
             "-d {$this->dbName}",
             "-U {$this->userName}",
-            "-W {$this->password}",
         ];
 
         $command[] = '-h '.($this->socket === '' ? $this->host : $this->socket);

--- a/src/Databases/PostgreSql.php
+++ b/src/Databases/PostgreSql.php
@@ -126,7 +126,13 @@ class PostgreSql extends DbDumper
 
         $command = $this->getDumpCommand($dumpFile);
 
-        $process = new Process($command);
+        $tempFileHandle = tmpfile();
+        fwrite($tempFileHandle, $this->getContentsOfCredentialsFile());
+        $temporaryCredentialsFile = stream_get_meta_data($tempFileHandle)['uri'];
+
+        $env = $this->getEnvForDumpCommand($temporaryCredentialsFile);
+
+        $process = new Process($command, null, $env);
 
         $process->run();
 
@@ -143,10 +149,9 @@ class PostgreSql extends DbDumper
     public function getDumpCommand($dumpFile)
     {
         $command = [
-            "PGPASSWORD='{$this->password}'",
             "{$this->dumpBinaryPath}pg_dump",
             "-d {$this->dbName}",
-            "-U {$this->userName}",
+            "-U {$this->userName}"
         ];
 
         $command[] = '-h '.($this->socket === '' ? $this->host : $this->socket);
@@ -156,6 +161,22 @@ class PostgreSql extends DbDumper
         return implode(' ', $command);
     }
 
+    /**
+     * @return string
+     */
+    public function getContentsOfCredentialsFile()
+    {
+        $contents = [
+            $this->host,
+            $this->port,
+            $this->dbName,
+            $this->userName,
+            $this->password,
+        ];
+
+        return implode(":", $contents);
+    }
+
     protected function guardAgainstIncompleteCredentials()
     {
         foreach (['userName', 'dbName', 'host'] as $requiredProperty) {
@@ -163,5 +184,16 @@ class PostgreSql extends DbDumper
                 throw CannotStartDump::emptyParameter($requiredProperty);
             }
         }
+    }
+
+    /**
+     * @param $temporaryCredentialsFile
+     * @return array
+     */
+    private function getEnvForDumpCommand($temporaryCredentialsFile)
+    {
+        return [
+            'PGPASSFILE' => $temporaryCredentialsFile
+        ];
     }
 }

--- a/tests/PostgreSqlTest.php
+++ b/tests/PostgreSqlTest.php
@@ -31,7 +31,7 @@ class PostgreSqlTest extends PHPUnit_Framework_TestCase
             ->setPassword('password')
             ->getDumpCommand('dump.sql');
 
-        $this->assertSame("PGPASSWORD='password' pg_dump -d dbname -U username -h localhost -p 5432 --file=dump.sql", $dumpCommand);
+        $this->assertSame("pg_dump -d dbname -U username -h localhost -p 5432 --file=dump.sql", $dumpCommand);
     }
 
     /** @test */
@@ -44,7 +44,7 @@ class PostgreSqlTest extends PHPUnit_Framework_TestCase
             ->setPort(1234)
             ->getDumpCommand('dump.sql');
 
-        $this->assertSame("PGPASSWORD='password' pg_dump -d dbname -U username -h localhost -p 1234 --file=dump.sql", $dumpCommand);
+        $this->assertSame("pg_dump -d dbname -U username -h localhost -p 1234 --file=dump.sql", $dumpCommand);
     }
 
     /** @test */
@@ -57,7 +57,7 @@ class PostgreSqlTest extends PHPUnit_Framework_TestCase
             ->setDumpBinaryPath('/custom/directory')
             ->getDumpCommand('dump.sql');
 
-        $this->assertSame("PGPASSWORD='password' /custom/directory/pg_dump -d dbname -U username -h localhost -p 5432 --file=dump.sql", $dumpCommand);
+        $this->assertSame("/custom/directory/pg_dump -d dbname -U username -h localhost -p 5432 --file=dump.sql", $dumpCommand);
     }
 
     /** @test */
@@ -70,7 +70,21 @@ class PostgreSqlTest extends PHPUnit_Framework_TestCase
             ->setSocket('/var/socket.1234')
             ->getDumpCommand('dump.sql');
 
-        $this->assertEquals("PGPASSWORD='password' pg_dump -d dbname -U username -h /var/socket.1234 -p 5432 --file=dump.sql", $dumpCommand);
+        $this->assertEquals("pg_dump -d dbname -U username -h /var/socket.1234 -p 5432 --file=dump.sql", $dumpCommand);
+    }
+
+    /** @test */
+    public function it_can_generate_the_contents_of_a_credentials_file()
+    {
+        $credentialsFileContent = PostgreSql::create()
+            ->setDbName('dbname')
+            ->setUserName('username')
+            ->setPassword('password')
+            ->setHost('hostname')
+            ->setPort(5432)
+            ->getContentsOfCredentialsFile();
+
+        $this->assertSame("hostname:5432:dbname:username:password", $credentialsFileContent);
     }
 
     /** @test */

--- a/tests/PostgreSqlTest.php
+++ b/tests/PostgreSqlTest.php
@@ -31,7 +31,7 @@ class PostgreSqlTest extends PHPUnit_Framework_TestCase
             ->setPassword('password')
             ->getDumpCommand('dump.sql');
 
-        $this->assertSame('pg_dump -d dbname -U username -W password -h localhost -p 5432 --file=dump.sql', $dumpCommand);
+        $this->assertSame("PGPASSWORD='password' pg_dump -d dbname -U username -h localhost -p 5432 --file=dump.sql", $dumpCommand);
     }
 
     /** @test */
@@ -44,7 +44,7 @@ class PostgreSqlTest extends PHPUnit_Framework_TestCase
             ->setPort(1234)
             ->getDumpCommand('dump.sql');
 
-        $this->assertSame('pg_dump -d dbname -U username -W password -h localhost -p 1234 --file=dump.sql', $dumpCommand);
+        $this->assertSame("PGPASSWORD='password' pg_dump -d dbname -U username -h localhost -p 1234 --file=dump.sql", $dumpCommand);
     }
 
     /** @test */
@@ -57,7 +57,7 @@ class PostgreSqlTest extends PHPUnit_Framework_TestCase
             ->setDumpBinaryPath('/custom/directory')
             ->getDumpCommand('dump.sql');
 
-        $this->assertSame('/custom/directory/pg_dump -d dbname -U username -W password -h localhost -p 5432 --file=dump.sql', $dumpCommand);
+        $this->assertSame("PGPASSWORD='password' /custom/directory/pg_dump -d dbname -U username -h localhost -p 5432 --file=dump.sql", $dumpCommand);
     }
 
     /** @test */
@@ -70,7 +70,7 @@ class PostgreSqlTest extends PHPUnit_Framework_TestCase
             ->setSocket('/var/socket.1234')
             ->getDumpCommand('dump.sql');
 
-        $this->assertEquals('pg_dump -d dbname -U username -W password -h /var/socket.1234 -p 5432 --file=dump.sql', $dumpCommand);
+        $this->assertEquals("PGPASSWORD='password' pg_dump -d dbname -U username -h /var/socket.1234 -p 5432 --file=dump.sql", $dumpCommand);
     }
 
     /** @test */


### PR DESCRIPTION
`-W` flag in `pg_dump` command according to [documentation](http://www.postgresql.org/docs/9.3/static/app-pgdump.html) doing this — «Force pg_dump to **prompt** for a password before connecting to a database.»

When we run command with this flag and password it just crush with error `too many command-line arguments`.

In `pg_dump` there is no flag for password, however we can set env variable `PGPASSWORD` and it will work.