### PR TITLE
Fix issue with paths containing spaces

### DIFF
--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -187,7 +187,7 @@ class MySql extends DbDumper
     {
         $command = [
             "{$this->dumpBinaryPath}mysqldump",
-            "--defaults-extra-file={$temporaryCredentialsFile}",
+            "--defaults-extra-file=\"{$temporaryCredentialsFile}\"",
             '--skip-comments',
             $this->useExtendedInserts ? '--extended-insert' : '--skip-extended-insert',
         ];
@@ -196,7 +196,7 @@ class MySql extends DbDumper
             $command[] = "--socket={$this->socket}";
         }
 
-        $command[] = "{$this->dbName} > {$dumpFile}";
+        $command[] = "{$this->dbName} > \"{$dumpFile}\"";
 
         return implode(' ', $command);
     }

--- a/src/Databases/PostgreSql.php
+++ b/src/Databases/PostgreSql.php
@@ -171,7 +171,7 @@ class PostgreSql extends DbDumper
 
         $command[] = '-h '.($this->socket === '' ? $this->host : $this->socket);
         $command[] = "-p {$this->port}";
-        $command[] = "--file={$dumpFile}";
+        $command[] = "--file=\"{$dumpFile}\"";
 
         return implode(' ', $command);
     }

--- a/tests/MySqlTest.php
+++ b/tests/MySqlTest.php
@@ -31,7 +31,7 @@ class MySqlTest extends PHPUnit_Framework_TestCase
             ->setPassword('password')
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('mysqldump --defaults-extra-file=credentials.txt --skip-comments --extended-insert dbname > dump.sql', $dumpCommand);
+        $this->assertSame('mysqldump --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname > "dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -44,7 +44,7 @@ class MySqlTest extends PHPUnit_Framework_TestCase
             ->dontUseExtendedInserts()
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('mysqldump --defaults-extra-file=credentials.txt --skip-comments --skip-extended-insert dbname > dump.sql', $dumpCommand);
+        $this->assertSame('mysqldump --defaults-extra-file="credentials.txt" --skip-comments --skip-extended-insert dbname > "dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -57,7 +57,7 @@ class MySqlTest extends PHPUnit_Framework_TestCase
             ->setDumpBinaryPath('/custom/directory')
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('/custom/directory/mysqldump --defaults-extra-file=credentials.txt --skip-comments --extended-insert dbname > dump.sql', $dumpCommand);
+        $this->assertSame('/custom/directory/mysqldump --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname > "dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -70,7 +70,7 @@ class MySqlTest extends PHPUnit_Framework_TestCase
             ->dontUseExtendedInserts()
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('mysqldump --defaults-extra-file=credentials.txt --skip-comments --skip-extended-insert dbname > dump.sql', $dumpCommand);
+        $this->assertSame('mysqldump --defaults-extra-file="credentials.txt" --skip-comments --skip-extended-insert dbname > "dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -83,7 +83,7 @@ class MySqlTest extends PHPUnit_Framework_TestCase
             ->setSocket(1234)
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('mysqldump --defaults-extra-file=credentials.txt --skip-comments --extended-insert --socket=1234 dbname > dump.sql', $dumpCommand);
+        $this->assertSame('mysqldump --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --socket=1234 dbname > "dump.sql"', $dumpCommand);
     }
 
     /** @test */

--- a/tests/PostgreSqlTest.php
+++ b/tests/PostgreSqlTest.php
@@ -31,7 +31,7 @@ class PostgreSqlTest extends PHPUnit_Framework_TestCase
             ->setPassword('password')
             ->getDumpCommand('dump.sql');
 
-        $this->assertSame('pg_dump -d dbname -U username -h localhost -p 5432 --file=dump.sql', $dumpCommand);
+        $this->assertSame('pg_dump -d dbname -U username -h localhost -p 5432 --file="dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -44,7 +44,7 @@ class PostgreSqlTest extends PHPUnit_Framework_TestCase
             ->setPort(1234)
             ->getDumpCommand('dump.sql');
 
-        $this->assertSame('pg_dump -d dbname -U username -h localhost -p 1234 --file=dump.sql', $dumpCommand);
+        $this->assertSame('pg_dump -d dbname -U username -h localhost -p 1234 --file="dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -57,7 +57,7 @@ class PostgreSqlTest extends PHPUnit_Framework_TestCase
             ->setDumpBinaryPath('/custom/directory')
             ->getDumpCommand('dump.sql');
 
-        $this->assertSame('/custom/directory/pg_dump -d dbname -U username -h localhost -p 5432 --file=dump.sql', $dumpCommand);
+        $this->assertSame('/custom/directory/pg_dump -d dbname -U username -h localhost -p 5432 --file="dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -70,7 +70,7 @@ class PostgreSqlTest extends PHPUnit_Framework_TestCase
             ->setSocket('/var/socket.1234')
             ->getDumpCommand('dump.sql');
 
-        $this->assertEquals('pg_dump -d dbname -U username -h /var/socket.1234 -p 5432 --file=dump.sql', $dumpCommand);
+        $this->assertEquals('pg_dump -d dbname -U username -h /var/socket.1234 -p 5432 --file="dump.sql"', $dumpCommand);
     }
 
     /** @test */


### PR DESCRIPTION
I had an issue getting up and running with `spatie/laravel-backup` that I traced to the `getDumpCommand` method in the `Spatie\DbDumper\Databases\MySql` class.

I'm on Windows and the temp directory path contained a space, which was causing `mysqldump` to fail. Fixed it by just adding quotes around the paths in the mysqldump command.