### PR TITLE
Better error dumping when backup fails

### DIFF
--- a/src/Exceptions/DumpFailed.php
+++ b/src/Exceptions/DumpFailed.php
@@ -14,7 +14,7 @@ class DumpFailed extends Exception
      */
     public static function processDidNotEndSuccessfully(Process $process)
     {
-        return new static("The dump process failed with exitcode {$process->getExitCode()} : {$process->getExitCodeText()}");
+        return new static("The dump process failed with exitcode {$process->getExitCode()} : {$process->getExitCodeText()} : {$process->getErrorOutput()}");
     }
 
     /**


### PR DESCRIPTION
This PR turns errors from
`The dump process failed with exitcode 1 : General error`
into
`The dump process failed with exitcode 1 : General error : pg_dump: [archiver] could not open output file "/var/www/test/storage/laravel-backups/temp//test.sql": No such file or directory`

Which is extremely helpful