### PR TITLE
Add option for --single-transaction in mysqldump

### DIFF
--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -16,6 +16,7 @@ class MySql extends DbDumper
     protected $socket;
     protected $dumpBinaryPath = '';
     protected $useExtendedInserts = true;
+    protected $useSingleTransaction = false;
     protected $timeout;
 
     /**
@@ -145,6 +146,26 @@ class MySql extends DbDumper
 
         return $this;
     }
+    
+    /**
+     * @return \Spatie\DbDumper\Databases\MySql
+     */
+    public function useSingleTransaction()
+    {
+        $this->useSingleTransaction = true;
+
+        return $this;
+    }
+
+    /**
+     * @return \Spatie\DbDumper\Databases\MySql
+     */
+    public function dontUseSingleTransaction()
+    {
+        $this->useSingleTransaction = false;
+
+        return $this;
+    }
 
     /**
      * Dump the contents of the database to the given file.
@@ -189,8 +210,12 @@ class MySql extends DbDumper
             "{$this->dumpBinaryPath}mysqldump",
             "--defaults-extra-file=\"{$temporaryCredentialsFile}\"",
             '--skip-comments',
-            $this->useExtendedInserts ? '--extended-insert' : '--skip-extended-insert',
+            $this->useExtendedInserts ? '--extended-insert' : '--skip-extended-insert'
         ];
+        
+        if($this->useSingleTransaction) {
+            $command[] = "--single-transaction";
+        }
 
         if ($this->socket != '') {
             $command[] = "--socket={$this->socket}";

--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -210,7 +210,7 @@ class MySql extends DbDumper
             "{$this->dumpBinaryPath}mysqldump",
             "--defaults-extra-file=\"{$temporaryCredentialsFile}\"",
             '--skip-comments',
-            $this->useExtendedInserts ? '--extended-insert' : '--skip-extended-insert'
+            $this->useExtendedInserts ? '--extended-insert' : '--skip-extended-insert',
         ];
         
         if($this->useSingleTransaction) {

--- a/tests/MySqlTest.php
+++ b/tests/MySqlTest.php
@@ -31,7 +31,7 @@ class MySqlTest extends PHPUnit_Framework_TestCase
             ->setPassword('password')
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('mysqldump --defaults-extra-file=credentials.txt --skip-comments --extended-insert dbname > dump.sql', $dumpCommand);
+        $this->assertSame('mysqldump --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname > "dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -44,7 +44,7 @@ class MySqlTest extends PHPUnit_Framework_TestCase
             ->dontUseExtendedInserts()
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('mysqldump --defaults-extra-file=credentials.txt --skip-comments --skip-extended-insert dbname > dump.sql', $dumpCommand);
+        $this->assertSame('mysqldump --defaults-extra-file="credentials.txt" --skip-comments --skip-extended-insert dbname > "dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -57,7 +57,7 @@ class MySqlTest extends PHPUnit_Framework_TestCase
             ->setDumpBinaryPath('/custom/directory')
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('/custom/directory/mysqldump --defaults-extra-file=credentials.txt --skip-comments --extended-insert dbname > dump.sql', $dumpCommand);
+        $this->assertSame('/custom/directory/mysqldump --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname > "dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -70,7 +70,7 @@ class MySqlTest extends PHPUnit_Framework_TestCase
             ->dontUseExtendedInserts()
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('mysqldump --defaults-extra-file=credentials.txt --skip-comments --skip-extended-insert dbname > dump.sql', $dumpCommand);
+        $this->assertSame('mysqldump --defaults-extra-file="credentials.txt" --skip-comments --skip-extended-insert dbname > "dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -83,7 +83,7 @@ class MySqlTest extends PHPUnit_Framework_TestCase
             ->setSocket(1234)
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('mysqldump --defaults-extra-file=credentials.txt --skip-comments --extended-insert --socket=1234 dbname > dump.sql', $dumpCommand);
+        $this->assertSame('mysqldump --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --socket=1234 dbname > "dump.sql"', $dumpCommand);
     }
 
     /** @test */


### PR DESCRIPTION
The `--single-transaction` flag prevents table locking while allowing for consistent data to be dumped from the database. It's a useful option that is often recommend when backing up large Mysql databases in production.

I set the default to `false` so that it won't affect anything without being specifically set.