### PR TITLE
Add --single-transaction option to Mysql dump command

### DIFF
--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -16,6 +16,7 @@ class MySql extends DbDumper
     protected $socket;
     protected $dumpBinaryPath = '';
     protected $useExtendedInserts = true;
+    protected $useSingleTransaction = false;
     protected $timeout;
 
     /**
@@ -147,6 +148,26 @@ class MySql extends DbDumper
     }
 
     /**
+     * @return \Spatie\DbDumper\Databases\MySql
+     */
+    public function useSingleTransaction()
+    {
+        $this->useSingleTransaction = true;
+
+        return $this;
+    }
+
+    /**
+     * @return \Spatie\DbDumper\Databases\MySql
+     */
+    public function dontUseSingleTransaction()
+    {
+        $this->useSingleTransaction = false;
+
+        return $this;
+    }
+
+    /**
      * Dump the contents of the database to the given file.
      *
      * @param string $dumpFile
@@ -191,6 +212,10 @@ class MySql extends DbDumper
             '--skip-comments',
             $this->useExtendedInserts ? '--extended-insert' : '--skip-extended-insert',
         ];
+
+        if ($this->useSingleTransaction) {
+            $command[] = "--single-transaction";
+        }
 
         if ($this->socket != '') {
             $command[] = "--socket={$this->socket}";

--- a/tests/MySqlTest.php
+++ b/tests/MySqlTest.php
@@ -74,6 +74,19 @@ class MySqlTest extends PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function it_can_generate_a_dump_command_using_single_transaction()
+    {
+        $dumpCommand = MySql::create()
+            ->setDbName('dbname')
+            ->setUserName('username')
+            ->setPassword('password')
+            ->useSingleTransaction()
+            ->getDumpCommand('dump.sql', 'credentials.txt');
+
+        $this->assertSame('mysqldump --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --single-transaction dbname > "dump.sql"', $dumpCommand);
+    }
+
+    /** @test */
     public function it_can_generate_a_dump_command_with_a_custom_socket()
     {
         $dumpCommand = MySql::create()


### PR DESCRIPTION
The `--single-transaction` flag is useful for large database dumps, as it prevents table locking while also ensuring consistent data. It is often recommended for backing up large production databases with InnoDB tables.

Set to `false` by default to prevent changing any existing setups.