### PR TITLE
Remove -d flag from pg_dump for compability with pgsql 7.3+

### DIFF
--- a/src/Databases/PostgreSql.php
+++ b/src/Databases/PostgreSql.php
@@ -228,7 +228,6 @@ class PostgreSql extends DbDumper
     {
         $command = [
             "{$this->dumpBinaryPath}pg_dump",
-            "-d {$this->dbName}",
             "-U {$this->userName}",
             '-h '.($this->socket === '' ? $this->host : $this->socket),
             "-p {$this->port}",
@@ -284,6 +283,7 @@ class PostgreSql extends DbDumper
     {
         return [
             'PGPASSFILE' => $temporaryCredentialsFile,
+            'PGDATABASE' => $this->dbName,
         ];
     }
 }

--- a/tests/PostgreSqlTest.php
+++ b/tests/PostgreSqlTest.php
@@ -32,7 +32,7 @@ class PostgreSqlTest extends PHPUnit_Framework_TestCase
             ->setPassword('password')
             ->getDumpCommand('dump.sql');
 
-        $this->assertSame('pg_dump -d dbname -U username -h localhost -p 5432 --file="dump.sql"', $dumpCommand);
+        $this->assertSame('pg_dump -U username -h localhost -p 5432 --file="dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -45,7 +45,7 @@ class PostgreSqlTest extends PHPUnit_Framework_TestCase
             ->useInserts()
             ->getDumpCommand('dump.sql');
 
-        $this->assertSame('pg_dump -d dbname -U username -h localhost -p 5432 --file="dump.sql" --inserts', $dumpCommand);
+        $this->assertSame('pg_dump -U username -h localhost -p 5432 --file="dump.sql" --inserts', $dumpCommand);
     }
 
     /** @test */
@@ -58,7 +58,7 @@ class PostgreSqlTest extends PHPUnit_Framework_TestCase
             ->setPort(1234)
             ->getDumpCommand('dump.sql');
 
-        $this->assertSame('pg_dump -d dbname -U username -h localhost -p 1234 --file="dump.sql"', $dumpCommand);
+        $this->assertSame('pg_dump -U username -h localhost -p 1234 --file="dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -71,7 +71,7 @@ class PostgreSqlTest extends PHPUnit_Framework_TestCase
             ->setDumpBinaryPath('/custom/directory')
             ->getDumpCommand('dump.sql');
 
-        $this->assertSame('/custom/directory/pg_dump -d dbname -U username -h localhost -p 5432 --file="dump.sql"', $dumpCommand);
+        $this->assertSame('/custom/directory/pg_dump -U username -h localhost -p 5432 --file="dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -84,7 +84,7 @@ class PostgreSqlTest extends PHPUnit_Framework_TestCase
             ->setSocket('/var/socket.1234')
             ->getDumpCommand('dump.sql');
 
-        $this->assertEquals('pg_dump -d dbname -U username -h /var/socket.1234 -p 5432 --file="dump.sql"', $dumpCommand);
+        $this->assertEquals('pg_dump -U username -h /var/socket.1234 -p 5432 --file="dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -97,7 +97,7 @@ class PostgreSqlTest extends PHPUnit_Framework_TestCase
             ->includeTables(['tb1', 'tb2', 'tb3'])
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('pg_dump -d dbname -U username -h localhost -p 5432 --file="dump.sql" -t tb1 -t tb2 -t tb3', $dumpCommand);
+        $this->assertSame('pg_dump -U username -h localhost -p 5432 --file="dump.sql" -t tb1 -t tb2 -t tb3', $dumpCommand);
     }
 
     /** @test */
@@ -110,7 +110,7 @@ class PostgreSqlTest extends PHPUnit_Framework_TestCase
             ->includeTables('tb1, tb2, tb3')
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('pg_dump -d dbname -U username -h localhost -p 5432 --file="dump.sql" -t tb1 -t tb2 -t tb3', $dumpCommand);
+        $this->assertSame('pg_dump -U username -h localhost -p 5432 --file="dump.sql" -t tb1 -t tb2 -t tb3', $dumpCommand);
     }
 
     /** @test */
@@ -136,7 +136,7 @@ class PostgreSqlTest extends PHPUnit_Framework_TestCase
             ->excludeTables(['tb1', 'tb2', 'tb3'])
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('pg_dump -d dbname -U username -h localhost -p 5432 --file="dump.sql" -T tb1 -T tb2 -T tb3', $dumpCommand);
+        $this->assertSame('pg_dump -U username -h localhost -p 5432 --file="dump.sql" -T tb1 -T tb2 -T tb3', $dumpCommand);
     }
 
     /** @test */
@@ -149,7 +149,7 @@ class PostgreSqlTest extends PHPUnit_Framework_TestCase
             ->excludeTables('tb1, tb2, tb3')
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('pg_dump -d dbname -U username -h localhost -p 5432 --file="dump.sql" -T tb1 -T tb2 -T tb3', $dumpCommand);
+        $this->assertSame('pg_dump -U username -h localhost -p 5432 --file="dump.sql" -T tb1 -T tb2 -T tb3', $dumpCommand);
     }
 
     /** @test */


### PR DESCRIPTION
According to this [issue](https://github.com/spatie/laravel-backup/issues/148) , it seems like pg_dump support `-d` flag only from versions 9.3+ (according to [changelog](https://www.postgresql.org/docs/9.3/static/release-9-3.html) E.27.3.9.2.)
I moved dbname to env process variable, which is supported starting from 7.3+.