### PR TITLE
Throw exception when the dbdump executable is not found.

### DIFF
--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -3,8 +3,8 @@
 namespace Spatie\DbDumper\Databases;
 
 use Spatie\DbDumper\DbDumper;
-use Spatie\DbDumper\Exceptions\CannotStartDump;
 use Spatie\DbDumper\Exceptions\CannotSetParameter;
+use Spatie\DbDumper\Exceptions\CannotStartDump;
 use Symfony\Component\Process\Process;
 
 class MySql extends DbDumper
@@ -18,8 +18,8 @@ class MySql extends DbDumper
     protected $dumpBinaryPath = '';
     protected $useExtendedInserts = true;
     protected $useSingleTransaction = false;
-    protected $includeTables = array();
-    protected $excludeTables = array();
+    protected $includeTables = [];
+    protected $excludeTables = [];
     protected $timeout;
 
     /**
@@ -255,7 +255,7 @@ class MySql extends DbDumper
             $this->useExtendedInserts ? '--extended-insert' : '--skip-extended-insert',
         ];
         if (!file_exists("{$this->dumpBinaryPath}mysqldump")) {
-            throw new \Exception("The mysqldump executable could not be found");
+            throw new \Exception('The mysqldump executable could not be found');
         }
 
         if ($this->useSingleTransaction) {

--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -227,7 +227,6 @@ class MySql extends DbDumper
         $temporaryCredentialsFile = stream_get_meta_data($tempFileHandle)['uri'];
 
         $command = $this->getDumpCommand($dumpFile, $temporaryCredentialsFile);
-
         $process = new Process($command);
 
         if (!is_null($this->timeout)) {
@@ -255,6 +254,9 @@ class MySql extends DbDumper
             '--skip-comments',
             $this->useExtendedInserts ? '--extended-insert' : '--skip-extended-insert',
         ];
+        if (!file_exists("{$this->dumpBinaryPath}mysqldump")) {
+            throw new \Exception("The mysqldump executable could not be found");
+        }
 
         if ($this->useSingleTransaction) {
             $command[] = '--single-transaction';

--- a/src/Databases/PostgreSql.php
+++ b/src/Databases/PostgreSql.php
@@ -3,8 +3,8 @@
 namespace Spatie\DbDumper\Databases;
 
 use Spatie\DbDumper\DbDumper;
-use Spatie\DbDumper\Exceptions\CannotStartDump;
 use Spatie\DbDumper\Exceptions\CannotSetParameter;
+use Spatie\DbDumper\Exceptions\CannotStartDump;
 use Symfony\Component\Process\Process;
 
 class PostgreSql extends DbDumper
@@ -17,8 +17,8 @@ class PostgreSql extends DbDumper
     protected $socket = '';
     protected $dumpBinaryPath = '';
     protected $useInserts = false;
-    protected $includeTables = array();
-    protected $excludeTables = array();
+    protected $includeTables = [];
+    protected $excludeTables = [];
     protected $timeout = null;
 
     /**
@@ -168,6 +168,7 @@ class PostgreSql extends DbDumper
 
         return $this;
     }
+
     /**
      * @return \Spatie\DbDumper\Databases\PostgreSql
      */
@@ -234,7 +235,7 @@ class PostgreSql extends DbDumper
             "--file=\"{$dumpFile}\"",
         ];
         if (!file_exists("{$this->dumpBinaryPath}pg_dump")) {
-            throw new \Exception("The pg_dump executable could not be found");
+            throw new \Exception('The pg_dump executable could not be found');
         }
         if ($this->useInserts) {
             $command[] = '--inserts';

--- a/src/Databases/PostgreSql.php
+++ b/src/Databases/PostgreSql.php
@@ -233,7 +233,9 @@ class PostgreSql extends DbDumper
             "-p {$this->port}",
             "--file=\"{$dumpFile}\"",
         ];
-
+        if (!file_exists("{$this->dumpBinaryPath}pg_dump")) {
+            throw new \Exception("The pg_dump executable could not be found");
+        }
         if ($this->useInserts) {
             $command[] = '--inserts';
         }


### PR DESCRIPTION
Hello,

First off--apologies for this being against the 1.5 branch.  I still need php5 support locally (though it looks like the diff is the same)

I'm not sure if this is the best way to solve the issue, but I was running into issues with spatie/laravel-backup if the executable did not exist when trying to run the command, because there was never an exception thrown for laravel-backup to catch.  This seemed like the best way to fix it, but you might have a better idea ;)