### PR TITLE
Add --default-character-set option for MySql

### DIFF
--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -17,6 +17,9 @@ class MySql extends DbDumper
     /** @var bool */
     protected $useSingleTransaction = false;
 
+    /** @var string */
+    protected $defaultCharacterSet = '';
+
     public function __construct()
     {
         $this->port = 3306;
@@ -78,6 +81,18 @@ class MySql extends DbDumper
     public function dontUseSingleTransaction()
     {
         $this->useSingleTransaction = false;
+
+        return $this;
+    }
+
+    /**
+     * @param string $characterSet
+     *
+     * @return $this
+     */
+    public function setDefaultCharacterSet(string $characterSet)
+    {
+        $this->defaultCharacterSet = $characterSet;
 
         return $this;
     }
@@ -146,17 +161,21 @@ class MySql extends DbDumper
             $command[] = '--ignore-table='.implode(' --ignore-table=', $this->excludeTables);
         }
 
+        if (! empty($this->defaultCharacterSet)) {
+            $command[] = '--default-character-set='.$this->defaultCharacterSet;
+        }
+
         foreach ($this->extraOptions as $extraOption) {
             $command[] = $extraOption;
         }
+
+        $command[] = "--result-file=\"{$dumpFile}\"";
 
         $command[] = "{$this->dbName}";
 
         if (! empty($this->includeTables)) {
             $command[] = implode(' ', $this->includeTables);
         }
-
-        $command[] = "> \"{$dumpFile}\"";
 
         return implode(' ', $command);
     }

--- a/tests/MySqlTest.php
+++ b/tests/MySqlTest.php
@@ -32,7 +32,7 @@ class MySqlTest extends PHPUnit_Framework_TestCase
             ->setPassword('password')
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname > "dump.sql"', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --result-file="dump.sql" dbname', $dumpCommand);
     }
 
     /** @test */
@@ -45,7 +45,7 @@ class MySqlTest extends PHPUnit_Framework_TestCase
             ->dontSkipComments()
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --extended-insert dbname > "dump.sql"', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --extended-insert --result-file="dump.sql" dbname', $dumpCommand);
     }
 
     /** @test */
@@ -58,7 +58,7 @@ class MySqlTest extends PHPUnit_Framework_TestCase
             ->dontUseExtendedInserts()
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --skip-extended-insert dbname > "dump.sql"', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --skip-extended-insert --result-file="dump.sql" dbname', $dumpCommand);
     }
 
     /** @test */
@@ -71,7 +71,7 @@ class MySqlTest extends PHPUnit_Framework_TestCase
             ->setDumpBinaryPath('/custom/directory')
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'/custom/directory/mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname > "dump.sql"', $dumpCommand);
+        $this->assertSame('\'/custom/directory/mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --result-file="dump.sql" dbname', $dumpCommand);
     }
 
     /** @test */
@@ -84,7 +84,7 @@ class MySqlTest extends PHPUnit_Framework_TestCase
             ->dontUseExtendedInserts()
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --skip-extended-insert dbname > "dump.sql"', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --skip-extended-insert --result-file="dump.sql" dbname', $dumpCommand);
     }
 
     /** @test */
@@ -97,7 +97,7 @@ class MySqlTest extends PHPUnit_Framework_TestCase
             ->useSingleTransaction()
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --single-transaction dbname > "dump.sql"', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --single-transaction --result-file="dump.sql" dbname', $dumpCommand);
     }
 
     /** @test */
@@ -110,7 +110,7 @@ class MySqlTest extends PHPUnit_Framework_TestCase
             ->setSocket(1234)
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --socket=1234 dbname > "dump.sql"', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --socket=1234 --result-file="dump.sql" dbname', $dumpCommand);
     }
 
     /** @test */
@@ -123,7 +123,7 @@ class MySqlTest extends PHPUnit_Framework_TestCase
             ->includeTables(['tb1', 'tb2', 'tb3'])
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname tb1 tb2 tb3 > "dump.sql"', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --result-file="dump.sql" dbname tb1 tb2 tb3', $dumpCommand);
     }
 
     /** @test */
@@ -136,7 +136,7 @@ class MySqlTest extends PHPUnit_Framework_TestCase
             ->includeTables('tb1 tb2 tb3')
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname tb1 tb2 tb3 > "dump.sql"', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --result-file="dump.sql" dbname tb1 tb2 tb3', $dumpCommand);
     }
 
     /** @test */
@@ -163,7 +163,7 @@ class MySqlTest extends PHPUnit_Framework_TestCase
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
         $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert '.
-            '--ignore-table=tb1 --ignore-table=tb2 --ignore-table=tb3 dbname > "dump.sql"', $dumpCommand);
+            '--ignore-table=tb1 --ignore-table=tb2 --ignore-table=tb3 --result-file="dump.sql" dbname', $dumpCommand);
     }
 
     /** @test */
@@ -177,7 +177,7 @@ class MySqlTest extends PHPUnit_Framework_TestCase
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
         $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert '.
-            '--ignore-table=tb1 --ignore-table=tb2 --ignore-table=tb3 dbname > "dump.sql"', $dumpCommand);
+            '--ignore-table=tb1 --ignore-table=tb2 --ignore-table=tb3 --result-file="dump.sql" dbname', $dumpCommand);
     }
 
     /** @test */
@@ -230,7 +230,7 @@ class MySqlTest extends PHPUnit_Framework_TestCase
             ->addExtraOption('--another-extra-option="value"')
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --extra-option --another-extra-option="value" dbname > "dump.sql"', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --extra-option --another-extra-option="value" --result-file="dump.sql" dbname', $dumpCommand);
     }
 
     /** @test */


### PR DESCRIPTION
Also started using `--result-file` instead of output redirection for `mysqldump` (it messes up the charset).

Postgres already dumps the database in its selected charset and sqlite should do the same (as far as I can read online)

Fixes #36 