### PR TITLE
Adding MongoDB dump

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 [![StyleCI](https://styleci.io/repos/49829051/shield?branch=master)](https://styleci.io/repos/49829051)
 [![Total Downloads](https://img.shields.io/packagist/dt/spatie/db-dumper.svg?style=flat-square)](https://packagist.org/packages/spatie/db-dumper)
 
-This repo contains an easy to use class to dump a database using PHP. Currently MySQL, PostgreSQL and SQLite are supported. Behind
-the scenes `mysqldump`, `pg_dump` and `sqlite3` are used.
+This repo contains an easy to use class to dump a database using PHP. Currently MySQL, PostgreSQL, SQLite and MongoDB are supported. Behind
+the scenes `mysqldump`, `pg_dump`, `sqlite3` and `mongodump` are used.
 
 Here's are simple examples of how to create a database dump with different drivers:
 
@@ -40,6 +40,16 @@ Spatie\DbDumper\Databases\Sqlite::create()
     ->dumpToFile('dump.sql');
 ```
 
+**MondoDB**
+
+```php
+Spatie\DbDumper\Databases\MongoDb::create()
+    ->setDbName($databaseName)
+    ->setUserName($userName)
+    ->setPassword($password)
+    ->dumpToFile('dump.gz');
+```
+
 Spatie is a webdesign agency based in Antwerp, Belgium. You'll find an overview of all our open source projects [on our website](https://spatie.be/opensource).
 
 ## Requirements
@@ -48,6 +58,8 @@ For dumping MySQL-db's `mysqldump` should be installed.
 For dumping PostgreSQL-db's `pg_dump` should be installed.
 
 For dumping SQLite-db's `sqlite3` should be installed.
+
+For dumping MongoDB-db's `mongodump` should be installed.
 
 ## Postcardware
 

--- a/src/Databases/MongoDb.php
+++ b/src/Databases/MongoDb.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Spatie\DbDumper\Databases;
+
+use Spatie\DbDumper\DbDumper;
+use Symfony\Component\Process\Process;
+use Spatie\DbDumper\Exceptions\CannotStartDump;
+
+class MongoDb extends DbDumper
+{
+    /**
+     * Mongodb Port.
+     * @var int
+     */
+    protected $port = 27017;
+
+    /**
+     * Collection to dump.
+     * @var null|string
+     */
+    protected $collection = null;
+
+    /**
+     * Dump the contents of the database to the given file.
+     *
+     * @param string $dumpFile
+     *
+     * @throws \Spatie\DbDumper\Exceptions\CannotStartDump
+     * @throws \Spatie\DbDumper\Exceptions\DumpFailed
+     */
+    public function dumpToFile(string $dumpFile)
+    {
+        $this->guardAgainstIncompleteCredentials();
+
+        $command = $this->getDumpCommand($dumpFile);
+
+        $process = new Process($command);
+
+        if (! is_null($this->timeout)) {
+            $process->setTimeout($this->timeout);
+        }
+
+        $process->run();
+
+        $this->checkIfDumpWasSuccessFul($process, $dumpFile);
+    }
+
+    /**
+     * Verifies if the dbname and host options are set.
+     *
+     * @throws \Spatie\DbDumper\Exceptions\CannotStartDump
+     * @return void
+     */
+    protected function guardAgainstIncompleteCredentials()
+    {
+        foreach (['dbName', 'host'] as $requiredProperty) {
+            if (strlen($this->$requiredProperty) === 0) {
+                throw CannotStartDump::emptyParameter($requiredProperty);
+            }
+        }
+    }
+
+    /**
+     * Set the collection property.
+     *
+     * @param  string $collection
+     * @return \Spatie\DbDumper\Databases\MongoDb
+     */
+    public function setCollection(string $collection)
+    {
+        $this->collection = $collection;
+
+        return $this;
+    }
+
+    /**
+     * Generate the dump command for MongoDb.
+     *
+     * @param  string $filename
+     * @return string
+     */
+    public function getDumpCommand(string $filename) : string
+    {
+        $command = [
+            "'{$this->dumpBinaryPath}mongodump'",
+            "--db {$this->dbName}",
+            '--gzip',
+            "--archive=$filename",
+        ];
+
+        if (isset($this->userName)) {
+            $command[] = "--username {$this->userName}";
+        }
+
+        if (isset($this->password)) {
+            $command[] = "--password {$this->password}";
+        }
+
+        if (isset($this->host)) {
+            $command[] = "--host {$this->host}";
+        }
+
+        if (isset($this->port)) {
+            $command[] = "--port {$this->port}";
+        }
+
+        if (isset($this->collection)) {
+            $command[] = "--collection {$this->collection}";
+        }
+
+        return implode(' ', $command);
+    }
+}

--- a/tests/MongoDbTest.php
+++ b/tests/MongoDbTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Spatie\DbDumper\Test;
+
+use PHPUnit_Framework_TestCase;
+use Spatie\DbDumper\Databases\MongoDb;
+use Spatie\DbDumper\Exceptions\CannotStartDump;
+
+class MongoDbTest extends PHPUnit_Framework_TestCase
+{
+    /** @test */
+    public function it_provides_a_factory_method()
+    {
+        $this->assertInstanceOf(MongoDb::class, MongoDb::create());
+    }
+
+    /** @test */
+    public function it_will_throw_an_exception_when_no_credentials_are_set()
+    {
+        $this->expectException(CannotStartDump::class);
+
+        MongoDb::create()->dumpToFile('test.gz');
+    }
+
+    /** @test */
+    public function it_can_generate_a_dump_command()
+    {
+        $dumpCommand = MongoDb::create()
+            ->setDbName('dbname')
+            ->getDumpCommand('dbname.gz');
+
+        $this->assertSame('\'mongodump\' --db dbname --gzip'
+            .' --archive=dbname.gz --host localhost --port 27017', $dumpCommand);
+    }
+
+    /** @test */
+    public function it_can_generate_a_dump_command_with_username_and_password()
+    {
+        $dumpCommand = MongoDb::create()
+            ->setDbName('dbname')
+            ->setUserName('username')
+            ->setPassword('password')
+            ->getDumpCommand('dbname.gz');
+
+        $this->assertSame('\'mongodump\' --db dbname --gzip --archive=dbname.gz'
+            .' --username username --password password --host localhost --port 27017', $dumpCommand);
+    }
+
+    /** @test */
+    public function it_can_generate_a_command_with_custom_host_and_port()
+    {
+        $dumpCommand = MongoDb::create()
+            ->setDbName('dbname')
+            ->setHost('mongodb.test.com')
+            ->setPort(27018)
+            ->getDumpCommand('dbname.gz');
+
+        $this->assertSame('\'mongodump\' --db dbname --gzip --archive=dbname.gz'
+         .' --host mongodb.test.com --port 27018', $dumpCommand);
+    }
+
+    /** @test */
+    public function it_can_generate_a_backup_command_for_a_single_collection()
+    {
+        $dumpCommand = MongoDb::create()
+            ->setDbName('dbname')
+            ->setCollection('mycollection')
+            ->getDumpCommand('dbname.gz');
+
+        $this->assertSame('\'mongodump\' --db dbname --gzip --archive=dbname.gz'
+            .' --host localhost --port 27017 --collection mycollection', $dumpCommand);
+    }
+
+    /** @test */
+    public function it_can_generate_a_dump_command_with_custom_binary_path()
+    {
+        $dumpCommand = MongoDb::create()
+            ->setDbName('dbname')
+            ->setDumpBinaryPath('/custom/directory')
+            ->getDumpCommand('dbname.gz');
+
+        $this->assertSame('\'/custom/directory/mongodump\' --db dbname --gzip --archive=dbname.gz'
+            .' --host localhost --port 27017', $dumpCommand);
+    }
+}


### PR DESCRIPTION
Added the ability to dump mongodb databases. The dumper will generate
the dump on a single file and gziped, using the mongodump native
compression feature.