### PR TITLE
put credentials file in same location as db dump to avoid system perm…

### DIFF
--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -109,7 +109,7 @@ class MySql extends DbDumper
     {
         $this->guardAgainstIncompleteCredentials();
 
-        $tempFileHandle = tmpfile();
+        $tempFileHandle = fopen($dumpFile . "_cred", "w+");
         fwrite($tempFileHandle, $this->getContentsOfCredentialsFile());
         $temporaryCredentialsFile = stream_get_meta_data($tempFileHandle)['uri'];
 

--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -109,7 +109,7 @@ class MySql extends DbDumper
     {
         $this->guardAgainstIncompleteCredentials();
 
-        $tempFileHandle = fopen($dumpFile . "_cred", "w+");
+        $tempFileHandle = fopen($dumpFile.'_cred', 'w+');
         fwrite($tempFileHandle, $this->getContentsOfCredentialsFile());
         $temporaryCredentialsFile = stream_get_meta_data($tempFileHandle)['uri'];
 


### PR DESCRIPTION
I am attempting to use this package as part of a web interface for managing backups of the application.  The tmpfile() command, used for the credentials file only, does not return a writeable path to apache on my system, and cannot be changed.  However, there is already a custom temporary file path being established for the actual db dump itself, which is writeable without issue.  This update puts the credentials file in the same path as the database dump, allowing this method to be run both from CLI or via the Artisan facade.

(Note - my sole use of this package is via laravel-backup)