### PR TITLE
make --databases optional as an extra option

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Spatie\DbDumper\Databases\MySql::create()
 
 
 ### Adding extra options
-If you want to add an arbitrary option to the dump command you can use `addOption`
+If you want to add an arbitrary option to the dump command you can use `addExtraOption`
 
 ```php
 $dumpCommand = MySql::create()
@@ -169,6 +169,21 @@ $dumpCommand = MySql::create()
     ->addExtraOption('--xml')
     ->getDumpCommand('dump.sql', 'credentials.txt');
 ```
+
+If you're working with MySql you can set the database name using `--databases` as an extra option. This is particularly useful when used in conjunction with the `--add-drop-database` `mysqldump` option (see the [mysqldump docs](https://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_add-drop-database)).
+
+```php
+$dumpCommand = MySql::create()
+    ->setUserName('username')
+    ->setPassword('password')
+    ->addExtraOption('--databases dbname')
+    ->addExtraOption('--add-drop-database')
+    ->getDumpCommand('dump.sql', 'credentials.txt');
+```
+
+Please note that using the `->addExtraOption('--databases dbname')` will override the database name set on a previous `->setDbName()` call.
+
+
 
 ## Changelog
 

--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -20,6 +20,9 @@ class MySql extends DbDumper
     /** @var string */
     protected $defaultCharacterSet = '';
 
+    /** @var bool */
+    protected $dbNameWasSetAsExtraOption = false;
+
     public function __construct()
     {
         $this->port = 3306;
@@ -126,6 +129,16 @@ class MySql extends DbDumper
         $this->checkIfDumpWasSuccessFul($process, $dumpFile);
     }
 
+    public function addExtraOption(string $extraOption)
+    {
+        if (preg_match('/^--databases (\S+)/', $extraOption, $matches) === 1) {
+            $this->setDbName($matches[1]);
+            $this->dbNameWasSetAsExtraOption = true;
+        }
+
+        return parent::addExtraOption($extraOption);
+    }
+
     /**
      * Get the command that should be performed to dump the database.
      *
@@ -171,7 +184,9 @@ class MySql extends DbDumper
 
         $command[] = "--result-file=\"{$dumpFile}\"";
 
-        $command[] = "--databases {$this->dbName}";
+        if (! $this->dbNameWasSetAsExtraOption) {
+            $command[] = $this->dbName;
+        }
 
         if (! empty($this->includeTables)) {
             $includeTables = implode(' ', $this->includeTables);

--- a/tests/MySqlTest.php
+++ b/tests/MySqlTest.php
@@ -32,7 +32,7 @@ class MySqlTest extends TestCase
             ->setPassword('password')
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --result-file="dump.sql" --databases dbname', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --result-file="dump.sql" dbname', $dumpCommand);
     }
 
     /** @test */
@@ -45,7 +45,7 @@ class MySqlTest extends TestCase
             ->dontSkipComments()
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --extended-insert --result-file="dump.sql" --databases dbname', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --extended-insert --result-file="dump.sql" dbname', $dumpCommand);
     }
 
     /** @test */
@@ -58,7 +58,7 @@ class MySqlTest extends TestCase
             ->dontUseExtendedInserts()
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --skip-extended-insert --result-file="dump.sql" --databases dbname', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --skip-extended-insert --result-file="dump.sql" dbname', $dumpCommand);
     }
 
     /** @test */
@@ -71,7 +71,7 @@ class MySqlTest extends TestCase
             ->setDumpBinaryPath('/custom/directory')
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'/custom/directory/mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --result-file="dump.sql" --databases dbname', $dumpCommand);
+        $this->assertSame('\'/custom/directory/mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --result-file="dump.sql" dbname', $dumpCommand);
     }
 
     /** @test */
@@ -84,7 +84,7 @@ class MySqlTest extends TestCase
             ->dontUseExtendedInserts()
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --skip-extended-insert --result-file="dump.sql" --databases dbname', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --skip-extended-insert --result-file="dump.sql" dbname', $dumpCommand);
     }
 
     /** @test */
@@ -97,7 +97,7 @@ class MySqlTest extends TestCase
             ->useSingleTransaction()
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --single-transaction --result-file="dump.sql" --databases dbname', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --single-transaction --result-file="dump.sql" dbname', $dumpCommand);
     }
 
     /** @test */
@@ -110,7 +110,7 @@ class MySqlTest extends TestCase
             ->setSocket(1234)
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --socket=1234 --result-file="dump.sql" --databases dbname', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --socket=1234 --result-file="dump.sql" dbname', $dumpCommand);
     }
 
     /** @test */
@@ -123,7 +123,7 @@ class MySqlTest extends TestCase
             ->includeTables(['tb1', 'tb2', 'tb3'])
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --result-file="dump.sql" --databases dbname --tables tb1 tb2 tb3', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --result-file="dump.sql" dbname --tables tb1 tb2 tb3', $dumpCommand);
     }
 
     /** @test */
@@ -136,7 +136,7 @@ class MySqlTest extends TestCase
             ->includeTables('tb1 tb2 tb3')
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --result-file="dump.sql" --databases dbname --tables tb1 tb2 tb3', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --result-file="dump.sql" dbname --tables tb1 tb2 tb3', $dumpCommand);
     }
 
     /** @test */
@@ -163,7 +163,7 @@ class MySqlTest extends TestCase
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
         $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert '.
-            '--ignore-table=dbname.tb1 --ignore-table=dbname.tb2 --ignore-table=dbname.tb3 --result-file="dump.sql" --databases dbname', $dumpCommand);
+                          '--ignore-table=dbname.tb1 --ignore-table=dbname.tb2 --ignore-table=dbname.tb3 --result-file="dump.sql" dbname', $dumpCommand);
     }
 
     /** @test */
@@ -177,11 +177,11 @@ class MySqlTest extends TestCase
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
         $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert '.
-            '--ignore-table=dbname.tb1 --ignore-table=dbname.tb2 --ignore-table=dbname.tb3 --result-file="dump.sql" --databases dbname', $dumpCommand);
+                          '--ignore-table=dbname.tb1 --ignore-table=dbname.tb2 --ignore-table=dbname.tb3 --result-file="dump.sql" dbname', $dumpCommand);
     }
 
     /** @test */
-    public function it_will_throw_an_exception_when_setting_tables_after_setting_esclude_tables()
+    public function it_will_throw_an_exception_when_setting_tables_after_setting_exclude_tables()
     {
         $this->expectException(CannotSetParameter::class);
 
@@ -230,7 +230,7 @@ class MySqlTest extends TestCase
             ->addExtraOption('--another-extra-option="value"')
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --extra-option --another-extra-option="value" --result-file="dump.sql" --databases dbname', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --extra-option --another-extra-option="value" --result-file="dump.sql" dbname', $dumpCommand);
     }
 
     /** @test */
@@ -239,5 +239,68 @@ class MySqlTest extends TestCase
         $dumper = MySql::create()->setHost('myHost');
 
         $this->assertEquals('myHost', $dumper->getHost());
+    }
+
+    /** @test */
+    public function it_can_set_db_name_as_an_extra_options()
+    {
+        $dumpCommand = MySql::create()
+            ->setUserName('username')
+            ->setPassword('password')
+            ->addExtraOption('--extra-option')
+            ->addExtraOption('--another-extra-option="value"')
+            ->addExtraOption('--databases dbname')
+            ->getDumpCommand('dump.sql', 'credentials.txt');
+
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --extra-option --another-extra-option="value" --databases dbname --result-file="dump.sql"', $dumpCommand);
+    }
+
+    /** @test */
+    public function it_can_get_the_name_of_the_db_when_dbname_was_set_as_an_extra_option()
+    {
+        $dbName = 'testName';
+
+        $dbDumper = MySql::create()->addExtraOption("--databases {$dbName}");
+
+        $this->assertEquals($dbName, $dbDumper->getDbName());
+    }
+
+    /** @test */
+    public function it_can_get_the_name_of_the_db_when_dbname_was_overriden_as_an_extra_option()
+    {
+        $dbName = 'testName';
+        $overridenDbName = 'otherName';
+
+        $dbDumper = MySql::create()->setDbName($dbName)->addExtraOption("--databases {$overridenDbName}");
+
+        $this->assertEquals($overridenDbName, $dbDumper->getDbName());
+    }
+
+    /** @test */
+    public function it_can_generate_a_dump_command_excluding_tables_as_array_when_dbname_was_set_as_an_extra_option()
+    {
+        $dumpCommand = MySql::create()
+            ->setUserName('username')
+            ->setPassword('password')
+            ->addExtraOption('--databases dbname')
+            ->excludeTables(['tb1', 'tb2', 'tb3'])
+            ->getDumpCommand('dump.sql', 'credentials.txt');
+
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert '.
+                          '--ignore-table=dbname.tb1 --ignore-table=dbname.tb2 --ignore-table=dbname.tb3 --databases dbname --result-file="dump.sql"', $dumpCommand);
+    }
+
+    /** @test */
+    public function it_can_generate_a_dump_command_excluding_tables_as_string_when_dbname_was_set_as_an_extra_option()
+    {
+        $dumpCommand = MySql::create()
+            ->setUserName('username')
+            ->setPassword('password')
+            ->addExtraOption('--databases dbname')
+            ->excludeTables('tb1, tb2, tb3')
+            ->getDumpCommand('dump.sql', 'credentials.txt');
+
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert '.
+                          '--ignore-table=dbname.tb1 --ignore-table=dbname.tb2 --ignore-table=dbname.tb3 --databases dbname --result-file="dump.sql"', $dumpCommand);
     }
 }


### PR DESCRIPTION
Address issue #57 

When a user wants to use the `--databases dbname` option she can add it as an extra-option like so:

~~~php
$dumpCommand = MySql::create()
    ->setUserName('username')
    ->setPassword('password')
    ->addExtraOption('--databases dbname')
    ->getDumpCommand('dump.sql', 'credentials.txt');
~~~

Setting the database name as such will override any prior calls to `->setDbName(...)`

Relevant tests were updated and added.
