### PR TITLE
Added gzip support for MySql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `db-dumper` will be documented in this file
 
+## 2.10.0 - 2018-04-27
+
+- add support for gzip to MySql, PostgreSql and Sqlite
+
 ## 2.9.0 - 2018-03-05
 
 - add support for setting `--set-gtid-purged`

--- a/src/Databases/MongoDb.php
+++ b/src/Databases/MongoDb.php
@@ -13,9 +13,6 @@ class MongoDb extends DbDumper
     /** @var null|string */
     protected $collection = null;
 
-    /** @var bool */
-    protected $enableCompression = false;
-
     /** @var null|string */
     protected $authenticationDatabase = null;
 
@@ -72,16 +69,6 @@ class MongoDb extends DbDumper
     }
 
     /**
-     * @return \Spatie\DbDumper\Databases\MongoDb
-     */
-    public function enableCompression()
-    {
-        $this->enableCompression = true;
-
-        return $this;
-    }
-
-    /**
      * @param string $authenticationDatabase
      *
      * @return \Spatie\DbDumper\Databases\MongoDb
@@ -130,10 +117,6 @@ class MongoDb extends DbDumper
 
         if ($this->authenticationDatabase) {
             $command[] = "--authenticationDatabase {$this->authenticationDatabase}";
-        }
-
-        if ($this->enableCompression) {
-            $command[] = '--gzip';
         }
 
         return $this->echoToFile(implode(' ', $command), $filename);

--- a/src/Databases/MongoDb.php
+++ b/src/Databases/MongoDb.php
@@ -105,7 +105,7 @@ class MongoDb extends DbDumper
         $command = [
             "'{$this->dumpBinaryPath}mongodump'",
             "--db {$this->dbName}",
-            "--archive=$filename",
+            "--archive",
         ];
 
         if ($this->userName) {
@@ -136,6 +136,6 @@ class MongoDb extends DbDumper
             $command[] = '--gzip';
         }
 
-        return implode(' ', $command);
+        return $this->echoToFile(implode(' ', $command), $filename);
     }
 }

--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -199,8 +199,6 @@ class MySql extends DbDumper
             $command[] = '--set-gtid-purged='.$this->setGtidPurged;
         }
 
-        $command[] = "--result-file=\"{$dumpFile}\"";
-
         if (! $this->dbNameWasSetAsExtraOption) {
             $command[] = $this->dbName;
         }
@@ -210,7 +208,7 @@ class MySql extends DbDumper
             $command[] = "--tables {$includeTables}";
         }
 
-        return implode(' ', $command);
+        return $this->echoToFile(implode(' ', $command), $dumpFile);
     }
 
     public function getContentsOfCredentialsFile(): string

--- a/src/Databases/PostgreSql.php
+++ b/src/Databases/PostgreSql.php
@@ -69,7 +69,6 @@ class PostgreSql extends DbDumper
             "-U {$this->userName}",
             '-h '.($this->socket === '' ? $this->host : $this->socket),
             "-p {$this->port}",
-            "--file=\"{$dumpFile}\"",
         ];
 
         if ($this->useInserts) {
@@ -88,7 +87,7 @@ class PostgreSql extends DbDumper
             $command[] = '-T '.implode(' -T ', $this->excludeTables);
         }
 
-        return implode(' ', $command);
+        return $this->echoToFile(implode(' ', $command), $dumpFile);
     }
 
     public function getContentsOfCredentialsFile(): string

--- a/src/Databases/Sqlite.php
+++ b/src/Databases/Sqlite.php
@@ -38,11 +38,11 @@ class Sqlite extends DbDumper
      */
     public function getDumpCommand(string $dumpFile): string
     {
-        return sprintf(
-            "echo 'BEGIN IMMEDIATE;\n.dump' | '%ssqlite3' --bail '%s' >'%s'",
+        $command = sprintf(
+            "echo 'BEGIN IMMEDIATE;\n.dump' | '%ssqlite3' --bail '%s'",
             $this->dumpBinaryPath,
-            $this->dbName,
-            $dumpFile
+            $this->dbName
         );
+        return $this->echoToFile($command, $dumpFile);
     }
 }

--- a/src/DbDumper.php
+++ b/src/DbDumper.php
@@ -41,6 +41,9 @@ abstract class DbDumper
     /** @var array */
     protected $extraOptions = [];
 
+    /** @var bool */
+    protected $enableCompression = false;
+
     public static function create()
     {
         return new static();
@@ -214,6 +217,16 @@ abstract class DbDumper
         return $this;
     }
 
+    /**
+     * @return $this
+     */
+    public function enableCompression()
+    {
+        $this->enableCompression = true;
+
+        return $this;
+    }
+
     abstract public function dumpToFile(string $dumpFile);
 
     protected function checkIfDumpWasSuccessFul(Process $process, string $outputFile)
@@ -238,6 +251,8 @@ abstract class DbDumper
      */
     protected function echoToFile(string $command, string $dumpFile)
     {
-        return $command . ' > ' . $dumpFile;
+        $compression = $this->enableCompression ? ' | gzip' : '';
+
+        return $command . $compression . ' > ' . $dumpFile;
     }
 }

--- a/src/DbDumper.php
+++ b/src/DbDumper.php
@@ -230,4 +230,14 @@ abstract class DbDumper
             throw DumpFailed::dumpfileWasEmpty();
         }
     }
+
+    /**
+     * @param string $command
+     *
+     * @return string
+     */
+    protected function echoToFile(string $command, string $dumpFile)
+    {
+        return $command . ' > ' . $dumpFile;
+    }
 }

--- a/tests/MongoDbTest.php
+++ b/tests/MongoDbTest.php
@@ -42,7 +42,7 @@ class MongoDbTest extends TestCase
             ->getDumpCommand('dbname.gz');
 
         $this->assertSame('\'mongodump\' --db dbname'
-            .' --archive --host localhost --port 27017 --gzip > dbname.gz', $dumpCommand);
+            .' --archive --host localhost --port 27017 | gzip > dbname.gz', $dumpCommand);
     }
 
     /** @test */

--- a/tests/MongoDbTest.php
+++ b/tests/MongoDbTest.php
@@ -30,7 +30,7 @@ class MongoDbTest extends TestCase
             ->getDumpCommand('dbname.gz');
 
         $this->assertSame('\'mongodump\' --db dbname'
-            .' --archive=dbname.gz --host localhost --port 27017', $dumpCommand);
+            .' --archive --host localhost --port 27017 > dbname.gz', $dumpCommand);
     }
 
     /** @test */
@@ -42,7 +42,7 @@ class MongoDbTest extends TestCase
             ->getDumpCommand('dbname.gz');
 
         $this->assertSame('\'mongodump\' --db dbname'
-            .' --archive=dbname.gz --host localhost --port 27017 --gzip', $dumpCommand);
+            .' --archive --host localhost --port 27017 --gzip > dbname.gz', $dumpCommand);
     }
 
     /** @test */
@@ -54,8 +54,8 @@ class MongoDbTest extends TestCase
             ->setPassword('password')
             ->getDumpCommand('dbname.gz');
 
-        $this->assertSame('\'mongodump\' --db dbname --archive=dbname.gz'
-            .' --username \'username\' --password \'password\' --host localhost --port 27017', $dumpCommand);
+        $this->assertSame('\'mongodump\' --db dbname --archive'
+            .' --username \'username\' --password \'password\' --host localhost --port 27017 > dbname.gz', $dumpCommand);
     }
 
     /** @test */
@@ -67,8 +67,8 @@ class MongoDbTest extends TestCase
             ->setPort(27018)
             ->getDumpCommand('dbname.gz');
 
-        $this->assertSame('\'mongodump\' --db dbname --archive=dbname.gz'
-         .' --host mongodb.test.com --port 27018', $dumpCommand);
+        $this->assertSame('\'mongodump\' --db dbname --archive'
+         .' --host mongodb.test.com --port 27018 > dbname.gz', $dumpCommand);
     }
 
     /** @test */
@@ -79,8 +79,8 @@ class MongoDbTest extends TestCase
             ->setCollection('mycollection')
             ->getDumpCommand('dbname.gz');
 
-        $this->assertSame('\'mongodump\' --db dbname --archive=dbname.gz'
-            .' --host localhost --port 27017 --collection mycollection', $dumpCommand);
+        $this->assertSame('\'mongodump\' --db dbname --archive'
+            .' --host localhost --port 27017 --collection mycollection > dbname.gz', $dumpCommand);
     }
 
     /** @test */
@@ -91,8 +91,8 @@ class MongoDbTest extends TestCase
             ->setDumpBinaryPath('/custom/directory')
             ->getDumpCommand('dbname.gz');
 
-        $this->assertSame('\'/custom/directory/mongodump\' --db dbname --archive=dbname.gz'
-            .' --host localhost --port 27017', $dumpCommand);
+        $this->assertSame('\'/custom/directory/mongodump\' --db dbname --archive'
+            .' --host localhost --port 27017 > dbname.gz', $dumpCommand);
     }
 
     /** @test */
@@ -103,7 +103,7 @@ class MongoDbTest extends TestCase
             ->setAuthenticationDatabase('admin')
             ->getDumpCommand('dbname.gz');
 
-        $this->assertSame('\'mongodump\' --db dbname --archive=dbname.gz'
-            .' --host localhost --port 27017 --authenticationDatabase admin', $dumpCommand);
+        $this->assertSame('\'mongodump\' --db dbname --archive'
+            .' --host localhost --port 27017 --authenticationDatabase admin > dbname.gz', $dumpCommand);
     }
 }

--- a/tests/MySqlTest.php
+++ b/tests/MySqlTest.php
@@ -36,6 +36,19 @@ class MySqlTest extends TestCase
     }
 
     /** @test */
+    public function it_can_generate_a_dump_command_with_compression_enabled()
+    {
+        $dumpCommand = MySql::create()
+            ->setDbName('dbname')
+            ->setUserName('username')
+            ->setPassword('password')
+            ->enableCompression()
+            ->getDumpCommand('dump.sql', 'credentials.txt');
+
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname | gzip > dump.sql', $dumpCommand);
+    }
+
+    /** @test */
     public function it_can_generate_a_dump_command_without_using_comments()
     {
         $dumpCommand = MySql::create()

--- a/tests/MySqlTest.php
+++ b/tests/MySqlTest.php
@@ -32,7 +32,7 @@ class MySqlTest extends TestCase
             ->setPassword('password')
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --result-file="dump.sql" dbname', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname > dump.sql', $dumpCommand);
     }
 
     /** @test */
@@ -45,7 +45,7 @@ class MySqlTest extends TestCase
             ->dontSkipComments()
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --extended-insert --result-file="dump.sql" dbname', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --extended-insert dbname > dump.sql', $dumpCommand);
     }
 
     /** @test */
@@ -58,7 +58,7 @@ class MySqlTest extends TestCase
             ->dontUseExtendedInserts()
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --skip-extended-insert --result-file="dump.sql" dbname', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --skip-extended-insert dbname > dump.sql', $dumpCommand);
     }
 
     /** @test */
@@ -71,7 +71,7 @@ class MySqlTest extends TestCase
             ->setDumpBinaryPath('/custom/directory')
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'/custom/directory/mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --result-file="dump.sql" dbname', $dumpCommand);
+        $this->assertSame('\'/custom/directory/mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname > dump.sql', $dumpCommand);
     }
 
     /** @test */
@@ -84,7 +84,7 @@ class MySqlTest extends TestCase
             ->dontUseExtendedInserts()
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --skip-extended-insert --result-file="dump.sql" dbname', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --skip-extended-insert dbname > dump.sql', $dumpCommand);
     }
 
     /** @test */
@@ -97,7 +97,7 @@ class MySqlTest extends TestCase
             ->useSingleTransaction()
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --single-transaction --result-file="dump.sql" dbname', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --single-transaction dbname > dump.sql', $dumpCommand);
     }
 
     /** @test */
@@ -110,7 +110,7 @@ class MySqlTest extends TestCase
             ->setSocket(1234)
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --socket=1234 --result-file="dump.sql" dbname', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --socket=1234 dbname > dump.sql', $dumpCommand);
     }
 
     /** @test */
@@ -123,7 +123,7 @@ class MySqlTest extends TestCase
             ->includeTables(['tb1', 'tb2', 'tb3'])
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --result-file="dump.sql" dbname --tables tb1 tb2 tb3', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname --tables tb1 tb2 tb3 > dump.sql', $dumpCommand);
     }
 
     /** @test */
@@ -136,7 +136,7 @@ class MySqlTest extends TestCase
             ->includeTables('tb1 tb2 tb3')
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --result-file="dump.sql" dbname --tables tb1 tb2 tb3', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname --tables tb1 tb2 tb3 > dump.sql', $dumpCommand);
     }
 
     /** @test */
@@ -163,7 +163,7 @@ class MySqlTest extends TestCase
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
         $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert '.
-                          '--ignore-table=dbname.tb1 --ignore-table=dbname.tb2 --ignore-table=dbname.tb3 --result-file="dump.sql" dbname', $dumpCommand);
+                          '--ignore-table=dbname.tb1 --ignore-table=dbname.tb2 --ignore-table=dbname.tb3 dbname > dump.sql', $dumpCommand);
     }
 
     /** @test */
@@ -177,7 +177,7 @@ class MySqlTest extends TestCase
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
         $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert '.
-                          '--ignore-table=dbname.tb1 --ignore-table=dbname.tb2 --ignore-table=dbname.tb3 --result-file="dump.sql" dbname', $dumpCommand);
+                          '--ignore-table=dbname.tb1 --ignore-table=dbname.tb2 --ignore-table=dbname.tb3 dbname > dump.sql', $dumpCommand);
     }
 
     /** @test */
@@ -230,7 +230,7 @@ class MySqlTest extends TestCase
             ->addExtraOption('--another-extra-option="value"')
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --extra-option --another-extra-option="value" --result-file="dump.sql" dbname', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --extra-option --another-extra-option="value" dbname > dump.sql', $dumpCommand);
     }
 
     /** @test */
@@ -252,7 +252,7 @@ class MySqlTest extends TestCase
             ->addExtraOption('--databases dbname')
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --extra-option --another-extra-option="value" --databases dbname --result-file="dump.sql"', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --extra-option --another-extra-option="value" --databases dbname > dump.sql', $dumpCommand);
     }
 
     /** @test */
@@ -287,7 +287,7 @@ class MySqlTest extends TestCase
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
         $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert '.
-                          '--ignore-table=dbname.tb1 --ignore-table=dbname.tb2 --ignore-table=dbname.tb3 --databases dbname --result-file="dump.sql"', $dumpCommand);
+                          '--ignore-table=dbname.tb1 --ignore-table=dbname.tb2 --ignore-table=dbname.tb3 --databases dbname > dump.sql', $dumpCommand);
     }
 
     /** @test */
@@ -301,7 +301,7 @@ class MySqlTest extends TestCase
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
         $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert '.
-                          '--ignore-table=dbname.tb1 --ignore-table=dbname.tb2 --ignore-table=dbname.tb3 --databases dbname --result-file="dump.sql"', $dumpCommand);
+                          '--ignore-table=dbname.tb1 --ignore-table=dbname.tb2 --ignore-table=dbname.tb3 --databases dbname > dump.sql', $dumpCommand);
     }
 
     /** @test */
@@ -314,6 +314,6 @@ class MySqlTest extends TestCase
             ->setGtidPurged('OFF')
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --set-gtid-purged=OFF --result-file="dump.sql" dbname', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --set-gtid-purged=OFF dbname > dump.sql', $dumpCommand);
     }
 }

--- a/tests/PostgreSqlTest.php
+++ b/tests/PostgreSqlTest.php
@@ -36,6 +36,19 @@ class PostgreSqlTest extends TestCase
     }
 
     /** @test */
+    public function it_can_generate_a_dump_command_with_compression_enabled()
+    {
+        $dumpCommand = PostgreSql::create()
+            ->setDbName('dbname')
+            ->setUserName('username')
+            ->setPassword('password')
+            ->enableCompression()
+            ->getDumpCommand('dump.sql');
+
+        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 | gzip > dump.sql', $dumpCommand);
+    }
+
+    /** @test */
     public function it_can_generate_a_dump_command_with_using_inserts()
     {
         $dumpCommand = PostgreSql::create()

--- a/tests/PostgreSqlTest.php
+++ b/tests/PostgreSqlTest.php
@@ -32,7 +32,7 @@ class PostgreSqlTest extends TestCase
             ->setPassword('password')
             ->getDumpCommand('dump.sql');
 
-        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 --file="dump.sql"', $dumpCommand);
+        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 > dump.sql', $dumpCommand);
     }
 
     /** @test */
@@ -45,7 +45,7 @@ class PostgreSqlTest extends TestCase
             ->useInserts()
             ->getDumpCommand('dump.sql');
 
-        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 --file="dump.sql" --inserts', $dumpCommand);
+        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 --inserts > dump.sql', $dumpCommand);
     }
 
     /** @test */
@@ -58,7 +58,7 @@ class PostgreSqlTest extends TestCase
             ->setPort(1234)
             ->getDumpCommand('dump.sql');
 
-        $this->assertSame('\'pg_dump\' -U username -h localhost -p 1234 --file="dump.sql"', $dumpCommand);
+        $this->assertSame('\'pg_dump\' -U username -h localhost -p 1234 > dump.sql', $dumpCommand);
     }
 
     /** @test */
@@ -71,7 +71,7 @@ class PostgreSqlTest extends TestCase
             ->setDumpBinaryPath('/custom/directory')
             ->getDumpCommand('dump.sql');
 
-        $this->assertSame('\'/custom/directory/pg_dump\' -U username -h localhost -p 5432 --file="dump.sql"', $dumpCommand);
+        $this->assertSame('\'/custom/directory/pg_dump\' -U username -h localhost -p 5432 > dump.sql', $dumpCommand);
     }
 
     /** @test */
@@ -84,7 +84,7 @@ class PostgreSqlTest extends TestCase
             ->setSocket('/var/socket.1234')
             ->getDumpCommand('dump.sql');
 
-        $this->assertEquals('\'pg_dump\' -U username -h /var/socket.1234 -p 5432 --file="dump.sql"', $dumpCommand);
+        $this->assertEquals('\'pg_dump\' -U username -h /var/socket.1234 -p 5432 > dump.sql', $dumpCommand);
     }
 
     /** @test */
@@ -97,7 +97,7 @@ class PostgreSqlTest extends TestCase
             ->includeTables(['tb1', 'tb2', 'tb3'])
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 --file="dump.sql" -t tb1 -t tb2 -t tb3', $dumpCommand);
+        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 -t tb1 -t tb2 -t tb3 > dump.sql', $dumpCommand);
     }
 
     /** @test */
@@ -110,7 +110,7 @@ class PostgreSqlTest extends TestCase
             ->includeTables('tb1, tb2, tb3')
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 --file="dump.sql" -t tb1 -t tb2 -t tb3', $dumpCommand);
+        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 -t tb1 -t tb2 -t tb3 > dump.sql', $dumpCommand);
     }
 
     /** @test */
@@ -136,7 +136,7 @@ class PostgreSqlTest extends TestCase
             ->excludeTables(['tb1', 'tb2', 'tb3'])
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 --file="dump.sql" -T tb1 -T tb2 -T tb3', $dumpCommand);
+        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 -T tb1 -T tb2 -T tb3 > dump.sql', $dumpCommand);
     }
 
     /** @test */
@@ -149,7 +149,7 @@ class PostgreSqlTest extends TestCase
             ->excludeTables('tb1, tb2, tb3')
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 --file="dump.sql" -T tb1 -T tb2 -T tb3', $dumpCommand);
+        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 -T tb1 -T tb2 -T tb3 > dump.sql', $dumpCommand);
     }
 
     /** @test */
@@ -199,7 +199,7 @@ class PostgreSqlTest extends TestCase
             ->addExtraOption('-something-else')
             ->getDumpCommand('dump.sql');
 
-        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 --file="dump.sql" -something-else', $dumpCommand);
+        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 -something-else > dump.sql', $dumpCommand);
     }
 
     /** @test */

--- a/tests/SqliteTest.php
+++ b/tests/SqliteTest.php
@@ -26,6 +26,19 @@ class SqliteTest extends TestCase
     }
 
     /** @test */
+    public function it_can_generate_a_dump_command_with_compression_enabled()
+    {
+        $dumpCommand = Sqlite::create()
+            ->setDbName('dbname.sqlite')
+            ->enableCompression()
+            ->getDumpCommand('dump.sql');
+
+        $expected = "echo 'BEGIN IMMEDIATE;\n.dump' | 'sqlite3' --bail 'dbname.sqlite' | gzip > dump.sql";
+
+        $this->assertEquals($expected, $dumpCommand);
+    }
+
+    /** @test */
     public function it_can_generate_a_dump_command_with_absolute_paths()
     {
         $dumpCommand = Sqlite::create()

--- a/tests/SqliteTest.php
+++ b/tests/SqliteTest.php
@@ -20,7 +20,7 @@ class SqliteTest extends TestCase
             ->setDbName('dbname.sqlite')
             ->getDumpCommand('dump.sql');
 
-        $expected = "echo 'BEGIN IMMEDIATE;\n.dump' | 'sqlite3' --bail 'dbname.sqlite' >'dump.sql'";
+        $expected = "echo 'BEGIN IMMEDIATE;\n.dump' | 'sqlite3' --bail 'dbname.sqlite' > dump.sql";
 
         $this->assertEquals($expected, $dumpCommand);
     }
@@ -33,7 +33,7 @@ class SqliteTest extends TestCase
             ->setDumpBinaryPath('/usr/bin')
             ->getDumpCommand('/save/to/dump.sql');
 
-        $expected = "echo 'BEGIN IMMEDIATE;\n.dump' | '/usr/bin/sqlite3' --bail '/path/to/dbname.sqlite' >'/save/to/dump.sql'";
+        $expected = "echo 'BEGIN IMMEDIATE;\n.dump' | '/usr/bin/sqlite3' --bail '/path/to/dbname.sqlite' > /save/to/dump.sql";
 
         $this->assertEquals($expected, $dumpCommand);
     }


### PR DESCRIPTION
By gzipping in the same command, it won't store any large mysql dump but it will stream the result to gzip. Saves a lot of space on disk.

PS. When this is approved and merged, I will do a PR for laravel/backup so gzip-option will use this instead of creating the dump first and do then the compression.