### PR TITLE
dump file output - fix for spaces in Osx directory name

### DIFF
--- a/src/DbDumper.php
+++ b/src/DbDumper.php
@@ -248,6 +248,6 @@ abstract class DbDumper
     {
         $compression = $this->enableCompression ? ' | gzip' : '';
 
-        return $command.$compression.' > '.$dumpFile;
+        return $command . $compression . ' > \'' . $dumpFile.'\'';
     }
 }


### PR DESCRIPTION
Found an error when dumping a db, discovered the spaces in directory name caused the problem. 