### PR TITLE
Allow destination paths to have a space character

### DIFF
--- a/src/DbDumper.php
+++ b/src/DbDumper.php
@@ -247,7 +247,7 @@ abstract class DbDumper
     protected function echoToFile(string $command, string $dumpFile): string
     {
         $compression = $this->enableCompression ? ' | gzip' : '';
-        $dumpFile    = '"'.addcslashes($dumpFile, '\\"').'"';
+        $dumpFile = '"'.addcslashes($dumpFile, '\\"').'"';
 
         return $command.$compression.' > '.$dumpFile;
     }

--- a/src/DbDumper.php
+++ b/src/DbDumper.php
@@ -247,7 +247,7 @@ abstract class DbDumper
     protected function echoToFile(string $command, string $dumpFile): string
     {
         $compression = $this->enableCompression ? ' | gzip' : '';
-        $dumpFile    = '"' . addcslashes($dumpFile, '\\"') . '"';
+        $dumpFile    = '"'.addcslashes($dumpFile, '\\"').'"';
 
         return $command.$compression.' > '.$dumpFile;
     }

--- a/src/DbDumper.php
+++ b/src/DbDumper.php
@@ -247,6 +247,7 @@ abstract class DbDumper
     protected function echoToFile(string $command, string $dumpFile): string
     {
         $compression = $this->enableCompression ? ' | gzip' : '';
+        $dumpFile    = '"' . addcslashes($dumpFile, '\\"') . '"';
 
         return $command.$compression.' > '.$dumpFile;
     }

--- a/tests/MongoDbTest.php
+++ b/tests/MongoDbTest.php
@@ -30,7 +30,7 @@ class MongoDbTest extends TestCase
             ->getDumpCommand('dbname.gz');
 
         $this->assertSame('\'mongodump\' --db dbname'
-            .' --archive --host localhost --port 27017 > dbname.gz', $dumpCommand);
+            .' --archive --host localhost --port 27017 > "dbname.gz"', $dumpCommand);
     }
 
     /** @test */
@@ -42,7 +42,7 @@ class MongoDbTest extends TestCase
             ->getDumpCommand('dbname.gz');
 
         $this->assertSame('\'mongodump\' --db dbname'
-            .' --archive --host localhost --port 27017 | gzip > dbname.gz', $dumpCommand);
+            .' --archive --host localhost --port 27017 | gzip > "dbname.gz"', $dumpCommand);
     }
 
     /** @test */
@@ -55,7 +55,7 @@ class MongoDbTest extends TestCase
             ->getDumpCommand('dbname.gz');
 
         $this->assertSame('\'mongodump\' --db dbname --archive'
-            .' --username \'username\' --password \'password\' --host localhost --port 27017 > dbname.gz', $dumpCommand);
+            .' --username \'username\' --password \'password\' --host localhost --port 27017 > "dbname.gz"', $dumpCommand);
     }
 
     /** @test */
@@ -68,7 +68,7 @@ class MongoDbTest extends TestCase
             ->getDumpCommand('dbname.gz');
 
         $this->assertSame('\'mongodump\' --db dbname --archive'
-         .' --host mongodb.test.com --port 27018 > dbname.gz', $dumpCommand);
+         .' --host mongodb.test.com --port 27018 > "dbname.gz"', $dumpCommand);
     }
 
     /** @test */
@@ -80,7 +80,7 @@ class MongoDbTest extends TestCase
             ->getDumpCommand('dbname.gz');
 
         $this->assertSame('\'mongodump\' --db dbname --archive'
-            .' --host localhost --port 27017 --collection mycollection > dbname.gz', $dumpCommand);
+            .' --host localhost --port 27017 --collection mycollection > "dbname.gz"', $dumpCommand);
     }
 
     /** @test */
@@ -92,7 +92,7 @@ class MongoDbTest extends TestCase
             ->getDumpCommand('dbname.gz');
 
         $this->assertSame('\'/custom/directory/mongodump\' --db dbname --archive'
-            .' --host localhost --port 27017 > dbname.gz', $dumpCommand);
+            .' --host localhost --port 27017 > "dbname.gz"', $dumpCommand);
     }
 
     /** @test */
@@ -104,6 +104,6 @@ class MongoDbTest extends TestCase
             ->getDumpCommand('dbname.gz');
 
         $this->assertSame('\'mongodump\' --db dbname --archive'
-            .' --host localhost --port 27017 --authenticationDatabase admin > dbname.gz', $dumpCommand);
+            .' --host localhost --port 27017 --authenticationDatabase admin > "dbname.gz"', $dumpCommand);
     }
 }

--- a/tests/MongoDbTest.php
+++ b/tests/MongoDbTest.php
@@ -55,7 +55,7 @@ class MongoDbTest extends TestCase
 
         $this->assertSame('\'mongodump\' --db dbname'
             .' --archive --host localhost --port 27017 | gzip > "/save/to/new (directory)/dbname.gz"', $dumpCommand);
-    }    
+    }
 
     /** @test */
     public function it_can_generate_a_dump_command_with_username_and_password()

--- a/tests/MongoDbTest.php
+++ b/tests/MongoDbTest.php
@@ -46,6 +46,18 @@ class MongoDbTest extends TestCase
     }
 
     /** @test */
+    public function it_can_generate_a_dump_command_with_absolute_path_having_space_and_brackets()
+    {
+        $dumpCommand = MongoDb::create()
+            ->setDbName('dbname')
+            ->enableCompression()
+            ->getDumpCommand('/save/to/new (directory)/dbname.gz');
+
+        $this->assertSame('\'mongodump\' --db dbname'
+            .' --archive --host localhost --port 27017 | gzip > "/save/to/new (directory)/dbname.gz"', $dumpCommand);
+    }    
+
+    /** @test */
     public function it_can_generate_a_dump_command_with_username_and_password()
     {
         $dumpCommand = MongoDb::create()

--- a/tests/MySqlTest.php
+++ b/tests/MySqlTest.php
@@ -49,6 +49,19 @@ class MySqlTest extends TestCase
     }
 
     /** @test */
+    public function it_can_generate_a_dump_command_with_absolute_path_having_space_and_brackets()
+    {
+        $dumpCommand = MySql::create()
+            ->setDbName('dbname')
+            ->setUserName('username')
+            ->setPassword('password')
+            ->enableCompression()
+            ->getDumpCommand('/save/to/new (directory)/dump.sql', 'credentials.txt');
+
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname | gzip > "/save/to/new (directory)/dump.sql"', $dumpCommand);
+    }
+
+    /** @test */
     public function it_can_generate_a_dump_command_without_using_comments()
     {
         $dumpCommand = MySql::create()

--- a/tests/MySqlTest.php
+++ b/tests/MySqlTest.php
@@ -32,7 +32,7 @@ class MySqlTest extends TestCase
             ->setPassword('password')
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname > dump.sql', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname > "dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -45,7 +45,7 @@ class MySqlTest extends TestCase
             ->enableCompression()
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname | gzip > dump.sql', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname | gzip > "dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -58,7 +58,7 @@ class MySqlTest extends TestCase
             ->dontSkipComments()
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --extended-insert dbname > dump.sql', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --extended-insert dbname > "dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -71,7 +71,7 @@ class MySqlTest extends TestCase
             ->dontUseExtendedInserts()
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --skip-extended-insert dbname > dump.sql', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --skip-extended-insert dbname > "dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -84,7 +84,7 @@ class MySqlTest extends TestCase
             ->setDumpBinaryPath('/custom/directory')
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'/custom/directory/mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname > dump.sql', $dumpCommand);
+        $this->assertSame('\'/custom/directory/mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname > "dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -97,7 +97,7 @@ class MySqlTest extends TestCase
             ->dontUseExtendedInserts()
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --skip-extended-insert dbname > dump.sql', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --skip-extended-insert dbname > "dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -110,7 +110,7 @@ class MySqlTest extends TestCase
             ->useSingleTransaction()
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --single-transaction dbname > dump.sql', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --single-transaction dbname > "dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -123,7 +123,7 @@ class MySqlTest extends TestCase
             ->setSocket(1234)
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --socket=1234 dbname > dump.sql', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --socket=1234 dbname > "dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -136,7 +136,7 @@ class MySqlTest extends TestCase
             ->includeTables(['tb1', 'tb2', 'tb3'])
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname --tables tb1 tb2 tb3 > dump.sql', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname --tables tb1 tb2 tb3 > "dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -149,7 +149,7 @@ class MySqlTest extends TestCase
             ->includeTables('tb1 tb2 tb3')
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname --tables tb1 tb2 tb3 > dump.sql', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname --tables tb1 tb2 tb3 > "dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -176,7 +176,7 @@ class MySqlTest extends TestCase
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
         $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert '.
-                          '--ignore-table=dbname.tb1 --ignore-table=dbname.tb2 --ignore-table=dbname.tb3 dbname > dump.sql', $dumpCommand);
+                          '--ignore-table=dbname.tb1 --ignore-table=dbname.tb2 --ignore-table=dbname.tb3 dbname > "dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -190,7 +190,7 @@ class MySqlTest extends TestCase
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
         $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert '.
-                          '--ignore-table=dbname.tb1 --ignore-table=dbname.tb2 --ignore-table=dbname.tb3 dbname > dump.sql', $dumpCommand);
+                          '--ignore-table=dbname.tb1 --ignore-table=dbname.tb2 --ignore-table=dbname.tb3 dbname > "dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -243,7 +243,7 @@ class MySqlTest extends TestCase
             ->addExtraOption('--another-extra-option="value"')
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --extra-option --another-extra-option="value" dbname > dump.sql', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --extra-option --another-extra-option="value" dbname > "dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -265,7 +265,7 @@ class MySqlTest extends TestCase
             ->addExtraOption('--databases dbname')
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --extra-option --another-extra-option="value" --databases dbname > dump.sql', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --extra-option --another-extra-option="value" --databases dbname > "dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -300,7 +300,7 @@ class MySqlTest extends TestCase
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
         $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert '.
-                          '--ignore-table=dbname.tb1 --ignore-table=dbname.tb2 --ignore-table=dbname.tb3 --databases dbname > dump.sql', $dumpCommand);
+                          '--ignore-table=dbname.tb1 --ignore-table=dbname.tb2 --ignore-table=dbname.tb3 --databases dbname > "dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -314,7 +314,7 @@ class MySqlTest extends TestCase
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
         $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert '.
-                          '--ignore-table=dbname.tb1 --ignore-table=dbname.tb2 --ignore-table=dbname.tb3 --databases dbname > dump.sql', $dumpCommand);
+                          '--ignore-table=dbname.tb1 --ignore-table=dbname.tb2 --ignore-table=dbname.tb3 --databases dbname > "dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -327,6 +327,6 @@ class MySqlTest extends TestCase
             ->setGtidPurged('OFF')
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --set-gtid-purged=OFF dbname > dump.sql', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --set-gtid-purged=OFF dbname > "dump.sql"', $dumpCommand);
     }
 }

--- a/tests/PostgreSqlTest.php
+++ b/tests/PostgreSqlTest.php
@@ -49,6 +49,19 @@ class PostgreSqlTest extends TestCase
     }
 
     /** @test */
+    public function it_can_generate_a_dump_command_with_absolute_path_having_space_and_brackets()
+    {
+        $dumpCommand = PostgreSql::create()
+            ->setDbName('dbname')
+            ->setUserName('username')
+            ->setPassword('password')
+            ->enableCompression()
+            ->getDumpCommand('/save/to/new (directory)/dump.sql');
+
+        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 | gzip > "/save/to/new (directory)/dump.sql"', $dumpCommand);
+    }   
+
+    /** @test */
     public function it_can_generate_a_dump_command_with_using_inserts()
     {
         $dumpCommand = PostgreSql::create()

--- a/tests/PostgreSqlTest.php
+++ b/tests/PostgreSqlTest.php
@@ -32,7 +32,7 @@ class PostgreSqlTest extends TestCase
             ->setPassword('password')
             ->getDumpCommand('dump.sql');
 
-        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 > dump.sql', $dumpCommand);
+        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 > "dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -45,7 +45,7 @@ class PostgreSqlTest extends TestCase
             ->enableCompression()
             ->getDumpCommand('dump.sql');
 
-        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 | gzip > dump.sql', $dumpCommand);
+        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 | gzip > "dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -58,7 +58,7 @@ class PostgreSqlTest extends TestCase
             ->useInserts()
             ->getDumpCommand('dump.sql');
 
-        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 --inserts > dump.sql', $dumpCommand);
+        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 --inserts > "dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -71,7 +71,7 @@ class PostgreSqlTest extends TestCase
             ->setPort(1234)
             ->getDumpCommand('dump.sql');
 
-        $this->assertSame('\'pg_dump\' -U username -h localhost -p 1234 > dump.sql', $dumpCommand);
+        $this->assertSame('\'pg_dump\' -U username -h localhost -p 1234 > "dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -84,7 +84,7 @@ class PostgreSqlTest extends TestCase
             ->setDumpBinaryPath('/custom/directory')
             ->getDumpCommand('dump.sql');
 
-        $this->assertSame('\'/custom/directory/pg_dump\' -U username -h localhost -p 5432 > dump.sql', $dumpCommand);
+        $this->assertSame('\'/custom/directory/pg_dump\' -U username -h localhost -p 5432 > "dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -97,7 +97,7 @@ class PostgreSqlTest extends TestCase
             ->setSocket('/var/socket.1234')
             ->getDumpCommand('dump.sql');
 
-        $this->assertEquals('\'pg_dump\' -U username -h /var/socket.1234 -p 5432 > dump.sql', $dumpCommand);
+        $this->assertEquals('\'pg_dump\' -U username -h /var/socket.1234 -p 5432 > "dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -110,7 +110,7 @@ class PostgreSqlTest extends TestCase
             ->includeTables(['tb1', 'tb2', 'tb3'])
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 -t tb1 -t tb2 -t tb3 > dump.sql', $dumpCommand);
+        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 -t tb1 -t tb2 -t tb3 > "dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -123,7 +123,7 @@ class PostgreSqlTest extends TestCase
             ->includeTables('tb1, tb2, tb3')
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 -t tb1 -t tb2 -t tb3 > dump.sql', $dumpCommand);
+        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 -t tb1 -t tb2 -t tb3 > "dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -149,7 +149,7 @@ class PostgreSqlTest extends TestCase
             ->excludeTables(['tb1', 'tb2', 'tb3'])
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 -T tb1 -T tb2 -T tb3 > dump.sql', $dumpCommand);
+        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 -T tb1 -T tb2 -T tb3 > "dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -162,7 +162,7 @@ class PostgreSqlTest extends TestCase
             ->excludeTables('tb1, tb2, tb3')
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 -T tb1 -T tb2 -T tb3 > dump.sql', $dumpCommand);
+        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 -T tb1 -T tb2 -T tb3 > "dump.sql"', $dumpCommand);
     }
 
     /** @test */
@@ -212,7 +212,7 @@ class PostgreSqlTest extends TestCase
             ->addExtraOption('-something-else')
             ->getDumpCommand('dump.sql');
 
-        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 -something-else > dump.sql', $dumpCommand);
+        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 -something-else > "dump.sql"', $dumpCommand);
     }
 
     /** @test */

--- a/tests/PostgreSqlTest.php
+++ b/tests/PostgreSqlTest.php
@@ -59,7 +59,7 @@ class PostgreSqlTest extends TestCase
             ->getDumpCommand('/save/to/new (directory)/dump.sql');
 
         $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 | gzip > "/save/to/new (directory)/dump.sql"', $dumpCommand);
-    }   
+    }
 
     /** @test */
     public function it_can_generate_a_dump_command_with_using_inserts()

--- a/tests/SqliteTest.php
+++ b/tests/SqliteTest.php
@@ -20,7 +20,7 @@ class SqliteTest extends TestCase
             ->setDbName('dbname.sqlite')
             ->getDumpCommand('dump.sql');
 
-        $expected = "echo 'BEGIN IMMEDIATE;\n.dump' | 'sqlite3' --bail 'dbname.sqlite' > dump.sql";
+        $expected = "echo 'BEGIN IMMEDIATE;\n.dump' | 'sqlite3' --bail 'dbname.sqlite' > \"dump.sql\"";
 
         $this->assertEquals($expected, $dumpCommand);
     }
@@ -33,7 +33,7 @@ class SqliteTest extends TestCase
             ->enableCompression()
             ->getDumpCommand('dump.sql');
 
-        $expected = "echo 'BEGIN IMMEDIATE;\n.dump' | 'sqlite3' --bail 'dbname.sqlite' | gzip > dump.sql";
+        $expected = "echo 'BEGIN IMMEDIATE;\n.dump' | 'sqlite3' --bail 'dbname.sqlite' | gzip > \"dump.sql\"";
 
         $this->assertEquals($expected, $dumpCommand);
     }
@@ -46,10 +46,23 @@ class SqliteTest extends TestCase
             ->setDumpBinaryPath('/usr/bin')
             ->getDumpCommand('/save/to/dump.sql');
 
-        $expected = "echo 'BEGIN IMMEDIATE;\n.dump' | '/usr/bin/sqlite3' --bail '/path/to/dbname.sqlite' > /save/to/dump.sql";
+        $expected = "echo 'BEGIN IMMEDIATE;\n.dump' | '/usr/bin/sqlite3' --bail '/path/to/dbname.sqlite' > \"/save/to/dump.sql\"";
 
         $this->assertEquals($expected, $dumpCommand);
     }
+
+    /** @test */
+    public function it_can_generate_a_dump_command_with_absolute_paths_having_space_and_quotes()
+    {
+        $dumpCommand = Sqlite::create()
+            ->setDbName('/path/to/dbname.sqlite')
+            ->setDumpBinaryPath('/usr/bin')
+            ->getDumpCommand('/save/to/new (directory)/dump.sql');
+
+        $expected = "echo 'BEGIN IMMEDIATE;\n.dump' | '/usr/bin/sqlite3' --bail '/path/to/dbname.sqlite' > \"/save/to/new (directory)/dump.sql\"";
+
+        $this->assertEquals($expected, $dumpCommand);
+    }    
 
     /** @test */
     public function it_successfully_creates_a_backup()

--- a/tests/SqliteTest.php
+++ b/tests/SqliteTest.php
@@ -52,7 +52,7 @@ class SqliteTest extends TestCase
     }
 
     /** @test */
-    public function it_can_generate_a_dump_command_with_absolute_paths_having_space_and_quotes()
+    public function it_can_generate_a_dump_command_with_absolute_paths_having_space_and_brackets()
     {
         $dumpCommand = Sqlite::create()
             ->setDbName('/path/to/dbname.sqlite')
@@ -62,7 +62,7 @@ class SqliteTest extends TestCase
         $expected = "echo 'BEGIN IMMEDIATE;\n.dump' | '/usr/bin/sqlite3' --bail '/path/to/dbname.sqlite' > \"/save/to/new (directory)/dump.sql\"";
 
         $this->assertEquals($expected, $dumpCommand);
-    }    
+    }
 
     /** @test */
     public function it_successfully_creates_a_backup()


### PR DESCRIPTION
- Wrap backup destination path in double quotes to allow it usage in shell
- Updated all tests to account for the added double quotes
- Added test cases for all databases to validate the correct generation of the backup command including absolute paths and space