### PR TITLE
Add compression strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `db-dumper` will be documented in this file
 
+## 2.10.2 - 2018-08-30
+
+- add bzip2 and lzma compressor options
+
 ## 2.10.1 - 2018-08-30
 
 - allow destination paths to have a space character

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ For dumping SQLite-db's `sqlite3` should be installed.
 
 For dumping MongoDB-db's `mongodump` should be installed.
 
-For using compression on the dump-result `gzip` should be installed.
+For using compression on the dump-result the command line compressor desired should be installed, either `gzip`, `bzip2` or `lzma`.
 
 ## Installation
 
@@ -179,17 +179,22 @@ Please note that using the `->addExtraOption('--databases dbname')` will overrid
 
 
 ### Use compression
-If you want to compress the outputted file, you can use `enableCompression`. This will stream the output of the dump trough `gzip`. The resulted dump file is now compressed.
+If you want to compress the outputted file, you can use one of the compressors and the resulted dump file will be compressed.
+
+There are three compressors `GzipCompressor`, `Bzip2Compressor` and `LzmaCompressor`, with `useCompressor` pass the desired compressor object.  This will stream the output of the dump trough `gzip`,  `bzip2` or `lzma`.
 
 ```php
 $dumpCommand = MySql::create()
     ->setDbName('dbname')
     ->setUserName('username')
     ->setPassword('password')
-    ->enableCompression()
+    ->useCompression(new GzipCompressor())
     ->dumpToFile('dump.sql.gz');
 ```
 
+You can add you own compressor implementing the `Compressor` contract.
+
+The `enableCompression()` will be removed in the next mayor version.
 
 ## Changelog
 
@@ -228,7 +233,7 @@ Initial PostgreSQL support was contributed by [Adriano Machado](https://github.c
 
 Spatie is a webdesign agency based in Antwerp, Belgium. You'll find an overview of all our open source projects [on our website](https://spatie.be/opensource).
 
-Does your business depend on our contributions? Reach out and support us on [Patreon](https://www.patreon.com/spatie). 
+Does your business depend on our contributions? Reach out and support us on [Patreon](https://www.patreon.com/spatie).
 All pledges will be dedicated to allocating workforce on maintenance and new awesome stuff.
 
 ## License

--- a/src/Compressors/Bzip2Compressor.php
+++ b/src/Compressors/Bzip2Compressor.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\DbDumper\Compressors;
+
+class Bzip2Compressor implements Compressor
+{
+    public function getCommand()
+    {
+        return 'bzip2 -f9';
+    }
+
+    public function getExtension()
+    {
+        return '.bz2';
+    }
+}

--- a/src/Compressors/Compressor.php
+++ b/src/Compressors/Compressor.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Spatie\DbDumper\Compressors;
+
+interface Compressor
+{
+    /** @return string */
+    public function getCommand();
+
+    /** @return string */
+    public function getExtension();
+}

--- a/src/Compressors/GzipCompressor.php
+++ b/src/Compressors/GzipCompressor.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\DbDumper\Compressors;
+
+class GzipCompressor implements Compressor
+{
+    public function getCommand()
+    {
+        return 'gzip';
+    }
+
+    public function getExtension()
+    {
+        return '.gz';
+    }
+}

--- a/src/Compressors/LzmaCompressor.php
+++ b/src/Compressors/LzmaCompressor.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\DbDumper\Compressors;
+
+class LzmaCompressor implements Compressor
+{
+    public function getCommand()
+    {
+        return 'lzma -ze';
+    }
+
+    public function getExtension()
+    {
+        return '.lzma';
+    }
+}

--- a/tests/MongoDbTest.php
+++ b/tests/MongoDbTest.php
@@ -4,7 +4,10 @@ namespace Spatie\DbDumper\Test;
 
 use PHPUnit\Framework\TestCase;
 use Spatie\DbDumper\Databases\MongoDb;
+use Spatie\DbDumper\Compressors\GzipCompressor;
+use Spatie\DbDumper\Compressors\LzmaCompressor;
 use Spatie\DbDumper\Exceptions\CannotStartDump;
+use Spatie\DbDumper\Compressors\Bzip2Compressor;
 
 class MongoDbTest extends TestCase
 {
@@ -46,11 +49,47 @@ class MongoDbTest extends TestCase
     }
 
     /** @test */
+    public function it_can_generate_a_dump_command_with_gzip_compressor_enabled()
+    {
+        $dumpCommand = MongoDb::create()
+            ->setDbName('dbname')
+            ->useCompression(new GzipCompressor)
+            ->getDumpCommand('dbname.gz');
+
+        $this->assertSame('\'mongodump\' --db dbname'
+            .' --archive --host localhost --port 27017 | gzip > "dbname.gz"', $dumpCommand);
+    }
+
+    /** @test */
+    public function it_can_generate_a_dump_command_with_bzip2_compressor_enabled()
+    {
+        $dumpCommand = MongoDb::create()
+            ->setDbName('dbname')
+            ->useCompression(new Bzip2Compressor)
+            ->getDumpCommand('dbname.bz2');
+
+        $this->assertSame('\'mongodump\' --db dbname'
+            .' --archive --host localhost --port 27017 | bzip2 -f9 > "dbname.bz2"', $dumpCommand);
+    }
+
+    /** @test */
+    public function it_can_generate_a_dump_command_with_lzma_compressor_enabled()
+    {
+        $dumpCommand = MongoDb::create()
+            ->setDbName('dbname')
+            ->useCompression(new LzmaCompressor)
+            ->getDumpCommand('dbname.lzma');
+
+        $this->assertSame('\'mongodump\' --db dbname'
+            .' --archive --host localhost --port 27017 | lzma -ze > "dbname.lzma"', $dumpCommand);
+    }
+
+    /** @test */
     public function it_can_generate_a_dump_command_with_absolute_path_having_space_and_brackets()
     {
         $dumpCommand = MongoDb::create()
             ->setDbName('dbname')
-            ->enableCompression()
+            ->useCompression(new GzipCompressor)
             ->getDumpCommand('/save/to/new (directory)/dbname.gz');
 
         $this->assertSame('\'mongodump\' --db dbname'

--- a/tests/MySqlTest.php
+++ b/tests/MySqlTest.php
@@ -4,7 +4,10 @@ namespace Spatie\DbDumper\Test;
 
 use PHPUnit\Framework\TestCase;
 use Spatie\DbDumper\Databases\MySql;
+use Spatie\DbDumper\Compressors\GzipCompressor;
+use Spatie\DbDumper\Compressors\LzmaCompressor;
 use Spatie\DbDumper\Exceptions\CannotStartDump;
+use Spatie\DbDumper\Compressors\Bzip2Compressor;
 use Spatie\DbDumper\Exceptions\CannotSetParameter;
 
 class MySqlTest extends TestCase
@@ -49,13 +52,52 @@ class MySqlTest extends TestCase
     }
 
     /** @test */
+    public function it_can_generate_a_dump_command_with_gzip_compressor_enabled()
+    {
+        $dumpCommand = MySql::create()
+            ->setDbName('dbname')
+            ->setUserName('username')
+            ->setPassword('password')
+            ->useCompression(new GzipCompressor)
+            ->getDumpCommand('dump.sql', 'credentials.txt');
+
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname | gzip > "dump.sql"', $dumpCommand);
+    }
+
+    /** @test */
+    public function it_can_generate_a_dump_command_with_bzip2_compressor_enabled()
+    {
+        $dumpCommand = MySql::create()
+            ->setDbName('dbname')
+            ->setUserName('username')
+            ->setPassword('password')
+            ->useCompression(new Bzip2Compressor)
+            ->getDumpCommand('dump.sql.bz2', 'credentials.txt');
+
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname | bzip2 -f9 > "dump.sql.bz2"', $dumpCommand);
+    }
+
+    /** @test */
+    public function it_can_generate_a_dump_command_with_lzma_compressor_enabled()
+    {
+        $dumpCommand = MySql::create()
+            ->setDbName('dbname')
+            ->setUserName('username')
+            ->setPassword('password')
+            ->useCompression(new LzmaCompressor)
+            ->getDumpCommand('dump.sql.lzma', 'credentials.txt');
+
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname | lzma -ze > "dump.sql.lzma"', $dumpCommand);
+    }
+
+    /** @test */
     public function it_can_generate_a_dump_command_with_absolute_path_having_space_and_brackets()
     {
         $dumpCommand = MySql::create()
             ->setDbName('dbname')
             ->setUserName('username')
             ->setPassword('password')
-            ->enableCompression()
+            ->useCompression(new GzipCompressor)
             ->getDumpCommand('/save/to/new (directory)/dump.sql', 'credentials.txt');
 
         $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname | gzip > "/save/to/new (directory)/dump.sql"', $dumpCommand);

--- a/tests/PostgreSqlTest.php
+++ b/tests/PostgreSqlTest.php
@@ -4,7 +4,10 @@ namespace Spatie\DbDumper\Test;
 
 use PHPUnit\Framework\TestCase;
 use Spatie\DbDumper\Databases\PostgreSql;
+use Spatie\DbDumper\Compressors\GzipCompressor;
+use Spatie\DbDumper\Compressors\LzmaCompressor;
 use Spatie\DbDumper\Exceptions\CannotStartDump;
+use Spatie\DbDumper\Compressors\Bzip2Compressor;
 use Spatie\DbDumper\Exceptions\CannotSetParameter;
 
 class PostgreSqlTest extends TestCase
@@ -49,13 +52,52 @@ class PostgreSqlTest extends TestCase
     }
 
     /** @test */
+    public function it_can_generate_a_dump_command_with_gzip_compressor_enabled()
+    {
+        $dumpCommand = PostgreSql::create()
+            ->setDbName('dbname')
+            ->setUserName('username')
+            ->setPassword('password')
+            ->useCompression(new GzipCompressor)
+            ->getDumpCommand('dump.sql');
+
+        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 | gzip > "dump.sql"', $dumpCommand);
+    }
+
+    /** @test */
+    public function it_can_generate_a_dump_command_with_bzip2_compressor_enabled()
+    {
+        $dumpCommand = PostgreSql::create()
+            ->setDbName('dbname')
+            ->setUserName('username')
+            ->setPassword('password')
+            ->useCompression(new Bzip2Compressor)
+            ->getDumpCommand('dump.sql.bz2');
+
+        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 | bzip2 -f9 > "dump.sql.bz2"', $dumpCommand);
+    }
+
+    /** @test */
+    public function it_can_generate_a_dump_command_with_lzma_compressor_enabled()
+    {
+        $dumpCommand = PostgreSql::create()
+            ->setDbName('dbname')
+            ->setUserName('username')
+            ->setPassword('password')
+            ->useCompression(new LzmaCompressor)
+            ->getDumpCommand('dump.sql.lzma');
+
+        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 | lzma -ze > "dump.sql.lzma"', $dumpCommand);
+    }
+
+    /** @test */
     public function it_can_generate_a_dump_command_with_absolute_path_having_space_and_brackets()
     {
         $dumpCommand = PostgreSql::create()
             ->setDbName('dbname')
             ->setUserName('username')
             ->setPassword('password')
-            ->enableCompression()
+            ->useCompression(new GzipCompressor)
             ->getDumpCommand('/save/to/new (directory)/dump.sql');
 
         $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 | gzip > "/save/to/new (directory)/dump.sql"', $dumpCommand);

--- a/tests/SqliteTest.php
+++ b/tests/SqliteTest.php
@@ -4,6 +4,9 @@ namespace Spatie\DbDumper\Test;
 
 use PHPUnit\Framework\TestCase;
 use Spatie\DbDumper\Databases\Sqlite;
+use Spatie\DbDumper\Compressors\GzipCompressor;
+use Spatie\DbDumper\Compressors\LzmaCompressor;
+use Spatie\DbDumper\Compressors\Bzip2Compressor;
 
 class SqliteTest extends TestCase
 {
@@ -34,6 +37,45 @@ class SqliteTest extends TestCase
             ->getDumpCommand('dump.sql');
 
         $expected = "echo 'BEGIN IMMEDIATE;\n.dump' | 'sqlite3' --bail 'dbname.sqlite' | gzip > \"dump.sql\"";
+
+        $this->assertEquals($expected, $dumpCommand);
+    }
+
+    /** @test */
+    public function it_can_generate_a_dump_command_with_gzip_compressor_enabled()
+    {
+        $dumpCommand = Sqlite::create()
+            ->setDbName('dbname.sqlite')
+            ->useCompression(new GzipCompressor)
+            ->getDumpCommand('dump.sql');
+
+        $expected = "echo 'BEGIN IMMEDIATE;\n.dump' | 'sqlite3' --bail 'dbname.sqlite' | gzip > \"dump.sql\"";
+
+        $this->assertEquals($expected, $dumpCommand);
+    }
+
+    /** @test */
+    public function it_can_generate_a_dump_command_with_bzip2_compressor_enabled()
+    {
+        $dumpCommand = Sqlite::create()
+            ->setDbName('dbname.sqlite')
+            ->useCompression(new Bzip2Compressor)
+            ->getDumpCommand('dump.sql.bz2');
+
+        $expected = "echo 'BEGIN IMMEDIATE;\n.dump' | 'sqlite3' --bail 'dbname.sqlite' | bzip2 -f9 > \"dump.sql.bz2\"";
+
+        $this->assertEquals($expected, $dumpCommand);
+    }
+
+    /** @test */
+    public function it_can_generate_a_dump_command_with_lzma_compressor_enabled()
+    {
+        $dumpCommand = Sqlite::create()
+            ->setDbName('dbname.sqlite')
+            ->useCompression(new LzmaCompressor)
+            ->getDumpCommand('dump.sql.lzma');
+
+        $expected = "echo 'BEGIN IMMEDIATE;\n.dump' | 'sqlite3' --bail 'dbname.sqlite' | lzma -ze > \"dump.sql.lzma\"";
 
         $this->assertEquals($expected, $dumpCommand);
     }


### PR DESCRIPTION
This came across when adding bzip2 to Laravel-Backup.

> bzip2 creates about 15% smaller files than gzip. bzip2 compresses somewhat slower than gzip, but seems that it hasn't prevented bzip2 from getting popular. 

For quote's source [here](https://tukaani.org/lzma/benchmarks.html)