### PR TITLE
Add command no create info

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,16 @@ Spatie\DbDumper\Databases\MySql::create()
     ->dumpToFile('dump.sql');
 ```
 
+### Do not write CREATE TABLE statements that create each dumped table.
+```php
+$dumpCommand = MySql::create()
+    ->setDbName('dbname')
+    ->setUserName('username')
+    ->setPassword('password')
+    ->noCreateInfo()
+    ->getDumpCommand('dump.sql', 'credentials.txt');
+```
+
 ### Adding extra options
 If you want to add an arbitrary option to the dump command you can use `addExtraOption`
 

--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -254,5 +254,4 @@ class MySql extends DbDumper
     {
         return strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' ? '"' : "'";
     }
-
 }

--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -26,7 +26,7 @@ class MySql extends DbDumper
     /** @var string */
     protected $setGtidPurged = 'AUTO';
 
-    /** @var bool  */
+    /** @var bool */
     protected $noCreateInfo = false;
 
     public function __construct()
@@ -183,7 +183,7 @@ class MySql extends DbDumper
         ];
 
         if ($this->noCreateInfo) {
-            $command[] = "--no-create-info";
+            $command[] = '--no-create-info';
         }
 
         if ($this->skipComments) {

--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -26,6 +26,9 @@ class MySql extends DbDumper
     /** @var string */
     protected $setGtidPurged = 'AUTO';
 
+    /** @var bool  */
+    protected $noCreateInfo = false;
+
     public function __construct()
     {
         $this->port = 3306;
@@ -153,6 +156,16 @@ class MySql extends DbDumper
     }
 
     /**
+     * @return $this
+     */
+    public function noCreateInfo()
+    {
+        $this->noCreateInfo = true;
+
+        return $this;
+    }
+
+    /**
      * Get the command that should be performed to dump the database.
      *
      * @param string $dumpFile
@@ -168,6 +181,10 @@ class MySql extends DbDumper
             "{$quote}{$this->dumpBinaryPath}mysqldump{$quote}",
             "--defaults-extra-file=\"{$temporaryCredentialsFile}\"",
         ];
+
+        if ($this->noCreateInfo) {
+            $command[] = "--no-create-info";
+        }
 
         if ($this->skipComments) {
             $command[] = '--skip-comments';
@@ -237,4 +254,5 @@ class MySql extends DbDumper
     {
         return strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' ? '"' : "'";
     }
+
 }

--- a/tests/MySqlTest.php
+++ b/tests/MySqlTest.php
@@ -356,4 +356,17 @@ class MySqlTest extends TestCase
 
         $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --set-gtid-purged=OFF dbname > "dump.sql"', $dumpCommand);
     }
+
+    /** @test */
+    public function it_can_generate_a_dump_command_with_no_create_info()
+    {
+        $dumpCommand = MySQL::create()
+            ->setDbName('dbname')
+            ->setUserName('username')
+            ->setPassword('password')
+            ->noCreateInfo()
+            ->getDumpCommand('dump.sql', 'credentials.txt');
+
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --no-create-info --skip-comments --extended-insert dbname > "dump.sql"', $dumpCommand);
+    }
 }


### PR DESCRIPTION
I have added the DDL option **--no-create-info** to do not create CREATE TABLE statements that create each dumped table (see: [MySQL 5.7 Reference DDL Options](https://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#mysqldump-ddl-options))

This option is useful to add several dumps to a table without dropping the table before.

A test for the new method MySQL::noCreateInfo() is added also. All unit tests are green.