### PR TITLE
Add ability to specify all databases as MySQL option

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,17 @@ $dumpCommand = MySql::create()
     ->getDumpCommand('dump.sql', 'credentials.txt');
 ```
 
-Please note that using the `->addExtraOption('--databases dbname')` will override the database name set on a previous `->setDbName()` call.
+With MySql, you also have the option to use the `--all-databases` extra option. This is useful when you want to run a full backup of all the databases in the specified MySQL connection.
+
+```php
+$dumpCommand = MySql::create()
+    ->setUserName('username')
+    ->setPassword('password')
+    ->addExtraOption('--all-databases')
+    ->getDumpCommand('dump.sql', 'credentials.txt');
+```
+
+Please note that using the `->addExtraOption('--databases dbname')` or `->addExtraOption('--all-databases')` will override the database name set on a previous `->setDbName()` call.
 
 ### Using compression
 If you want to compress the outputted file, you can use one of the compressors and the resulted dump file will be compressed.

--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -257,7 +257,7 @@ class MySql extends DbDumper
             }
         }
 
-        if (strlen('dbName') === 0 && !$this->allDatabasesWasSetAsExtraOption) {
+        if (strlen('dbName') === 0 && ! $this->allDatabasesWasSetAsExtraOption) {
             throw CannotStartDump::emptyParameter($requiredProperty);
         }
     }

--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -23,6 +23,9 @@ class MySql extends DbDumper
     /** @var bool */
     protected $dbNameWasSetAsExtraOption = false;
 
+    /** @var bool */
+    protected $allDatabasesWasSetAsExtraOption = false;
+
     /** @var string */
     protected $setGtidPurged = 'AUTO';
 
@@ -147,6 +150,11 @@ class MySql extends DbDumper
 
     public function addExtraOption(string $extraOption)
     {
+        if (strpos($extraOption, '--all-databases') !== false) {
+            $this->dbNameWasSetAsExtraOption = true;
+            $this->allDatabasesWasSetAsExtraOption = true;
+        }
+
         if (preg_match('/^--databases (\S+)/', $extraOption, $matches) === 1) {
             $this->setDbName($matches[1]);
             $this->dbNameWasSetAsExtraOption = true;
@@ -243,10 +251,14 @@ class MySql extends DbDumper
 
     protected function guardAgainstIncompleteCredentials()
     {
-        foreach (['userName', 'dbName', 'host'] as $requiredProperty) {
+        foreach (['userName', 'host'] as $requiredProperty) {
             if (strlen($this->$requiredProperty) === 0) {
                 throw CannotStartDump::emptyParameter($requiredProperty);
             }
+        }
+
+        if (strlen('dbName') === 0 && !$this->allDatabasesWasSetAsExtraOption) {
+            throw CannotStartDump::emptyParameter($requiredProperty);
         }
     }
 

--- a/tests/MySqlTest.php
+++ b/tests/MySqlTest.php
@@ -317,6 +317,18 @@ class MySqlTest extends TestCase
     }
 
     /** @test */
+    public function it_can_get_the_name_of_the_db_when_all_databases_was_set_as_an_extra_option()
+    {
+        $dumpCommand = MySql::create()
+            ->setUserName('username')
+            ->setPassword('password')
+            ->addExtraOption('--all-databases')
+            ->getDumpCommand('dump.sql', 'credentials.txt');
+
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --all-databases > "dump.sql"', $dumpCommand);
+    }
+
+    /** @test */
     public function it_can_generate_a_dump_command_excluding_tables_as_array_when_dbname_was_set_as_an_extra_option()
     {
         $dumpCommand = MySql::create()


### PR DESCRIPTION
This PR allows the "--all-databases" argument to be passed to the MySQL DB Dumper. Using this will override any passed database, and will allow the user to back up all databases present in the specified MySQL connection.

This is extremely useful for taking full backups that can be used in cloning servers, fully restoring after a server crash, and in many other scenarios.