### PR TITLE
Add --skip-lock-tables and --quick option

### DIFF
--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -17,6 +17,9 @@ class MySql extends DbDumper
     /** @var bool */
     protected $useSingleTransaction = false;
 
+    /** @var bool */
+    protected $skipLockTables = false;
+
     /** @var string */
     protected $defaultCharacterSet = '';
 
@@ -93,6 +96,26 @@ class MySql extends DbDumper
     public function dontUseSingleTransaction()
     {
         $this->useSingleTransaction = false;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function skipLockTables()
+    {
+        $this->skipLockTables = true;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function dontSkipLockTables()
+    {
+        $this->skipLockTables = false;
 
         return $this;
     }
@@ -198,6 +221,10 @@ class MySql extends DbDumper
 
         if ($this->useSingleTransaction) {
             $command[] = '--single-transaction';
+        }
+
+        if ($this->skipLockTables) {
+            $command[] = '--skip-lock-tables';
         }
 
         if ($this->socket !== '') {

--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -20,6 +20,9 @@ class MySql extends DbDumper
     /** @var bool */
     protected $skipLockTables = false;
 
+    /** @var bool */
+    protected $useQuick = false;
+
     /** @var string */
     protected $defaultCharacterSet = '';
 
@@ -116,6 +119,26 @@ class MySql extends DbDumper
     public function dontSkipLockTables()
     {
         $this->skipLockTables = false;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function useQuick()
+    {
+        $this->useQuick = true;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function dontUseQuick()
+    {
+        $this->useQuick = false;
 
         return $this;
     }
@@ -225,6 +248,10 @@ class MySql extends DbDumper
 
         if ($this->skipLockTables) {
             $command[] = '--skip-lock-tables';
+        }
+
+        if ($this->useQuick) {
+            $command[] = '--quick';
         }
 
         if ($this->socket !== '') {

--- a/tests/MySqlTest.php
+++ b/tests/MySqlTest.php
@@ -141,6 +141,19 @@ class MySqlTest extends TestCase
     }
 
     /** @test */
+    public function it_can_generate_a_dump_command_using_skip_lock_tables()
+    {
+        $dumpCommand = MySql::create()
+            ->setDbName('dbname')
+            ->setUserName('username')
+            ->setPassword('password')
+            ->skipLockTables()
+            ->getDumpCommand('dump.sql', 'credentials.txt');
+
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --skip-lock-tables dbname > "dump.sql"', $dumpCommand);
+    }
+
+    /** @test */
     public function it_can_generate_a_dump_command_with_a_custom_socket()
     {
         $dumpCommand = MySql::create()

--- a/tests/MySqlTest.php
+++ b/tests/MySqlTest.php
@@ -154,6 +154,19 @@ class MySqlTest extends TestCase
     }
 
     /** @test */
+    public function it_can_generate_a_dump_command_using_quick()
+    {
+        $dumpCommand = MySql::create()
+            ->setDbName('dbname')
+            ->setUserName('username')
+            ->setPassword('password')
+            ->useQuick()
+            ->getDumpCommand('dump.sql', 'credentials.txt');
+
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --quick dbname > "dump.sql"', $dumpCommand);
+    }
+
+    /** @test */
     public function it_can_generate_a_dump_command_with_a_custom_socket()
     {
         $dumpCommand = MySql::create()


### PR DESCRIPTION
I have added the --skip-lock-tables option which prevents InnoDB tables to be locked while performing a mysqldump. It should be used together with --use-single-transaction for data consistency according to [this serversforhackers tutorial](https://serversforhackers.com/c/mysqldump-with-modern-mysql).
I also created the corresponding test. 