### PR TITLE
Wrap dump command in an if when using compression, fixes #89

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php" : "^7.1",
+        "php" : "^7.3",
         "symfony/process": "^4.2"
     },
     "require-dev": {

--- a/src/DbDumper.php
+++ b/src/DbDumper.php
@@ -263,8 +263,12 @@ abstract class DbDumper
             $compressCommand = $this->compressor->useCommand();
 
             return <<<BASH
-if output=\$({$command}); then
+if output=\$({$command});
+then
   echo "\$output" | $compressCommand > $dumpFile
+else
+  echo "Dump was not succesful." >&2
+  exit 1
 fi
 BASH;
         }

--- a/src/DbDumper.php
+++ b/src/DbDumper.php
@@ -263,14 +263,14 @@ abstract class DbDumper
             $compressCommand = $this->compressor->useCommand();
 
             return <<<BASH
-if output=\$({$command});
-then
-  echo "\$output" | $compressCommand > $dumpFile
-else
-  echo "Dump was not succesful." >&2
-  exit 1
-fi
-BASH;
+            if output=\$({$command});
+            then
+              echo "\$output" | $compressCommand > $dumpFile
+            else
+              echo "Dump was not succesful." >&2
+              exit 1
+            fi
+            BASH;
         }
 
         return $command.' > '.$dumpFile;

--- a/src/DbDumper.php
+++ b/src/DbDumper.php
@@ -257,12 +257,18 @@ abstract class DbDumper
 
     protected function echoToFile(string $command, string $dumpFile): string
     {
-        $compressor = $this->compressor
-            ? ' | '.$this->compressor->useCommand()
-            : '';
-
         $dumpFile = '"'.addcslashes($dumpFile, '\\"').'"';
 
-        return $command.$compressor.' > '.$dumpFile;
+        if ($this->compressor) {
+            $compressCommand = $this->compressor->useCommand();
+
+            return <<<BASH
+if output=\$({$command}); then
+  echo "\$output" | $compressCommand > $dumpFile
+fi
+BASH;
+        }
+
+        return $command . ' > ' . $dumpFile;
     }
 }

--- a/src/DbDumper.php
+++ b/src/DbDumper.php
@@ -273,6 +273,6 @@ fi
 BASH;
         }
 
-        return $command . ' > ' . $dumpFile;
+        return $command.' > '.$dumpFile;
     }
 }

--- a/tests/MongoDbTest.php
+++ b/tests/MongoDbTest.php
@@ -42,8 +42,12 @@ class MongoDbTest extends TestCase
             ->enableCompression()
             ->getDumpCommand('dbname.gz');
 
-        $this->assertSame('if output=$(\'mongodump\' --db dbname --archive --host localhost --port 27017); then
+        $this->assertSame('if output=$(\'mongodump\' --db dbname --archive --host localhost --port 27017);
+then
   echo "$output" | gzip > "dbname.gz"
+else
+  echo "Dump was not succesful." >&2
+  exit 1
 fi', $dumpCommand);
     }
 
@@ -55,8 +59,12 @@ fi', $dumpCommand);
             ->useCompressor(new GzipCompressor)
             ->getDumpCommand('dbname.gz');
 
-        $this->assertSame('if output=$(\'mongodump\' --db dbname --archive --host localhost --port 27017); then
+        $this->assertSame('if output=$(\'mongodump\' --db dbname --archive --host localhost --port 27017);
+then
   echo "$output" | gzip > "dbname.gz"
+else
+  echo "Dump was not succesful." >&2
+  exit 1
 fi', $dumpCommand);
     }
 
@@ -68,8 +76,12 @@ fi', $dumpCommand);
             ->useCompressor(new GzipCompressor)
             ->getDumpCommand('/save/to/new (directory)/dbname.gz');
 
-        $this->assertSame('if output=$(\'mongodump\' --db dbname --archive --host localhost --port 27017); then
+        $this->assertSame('if output=$(\'mongodump\' --db dbname --archive --host localhost --port 27017);
+then
   echo "$output" | gzip > "/save/to/new (directory)/dbname.gz"
+else
+  echo "Dump was not succesful." >&2
+  exit 1
 fi', $dumpCommand);
     }
 

--- a/tests/MongoDbTest.php
+++ b/tests/MongoDbTest.php
@@ -73,16 +73,9 @@ fi', $dumpCommand);
     {
         $dumpCommand = MongoDb::create()
             ->setDbName('dbname')
-            ->useCompressor(new GzipCompressor)
             ->getDumpCommand('/save/to/new (directory)/dbname.gz');
 
-        $this->assertSame('if output=$(\'mongodump\' --db dbname --archive --host localhost --port 27017);
-then
-  echo "$output" | gzip > "/save/to/new (directory)/dbname.gz"
-else
-  echo "Dump was not succesful." >&2
-  exit 1
-fi', $dumpCommand);
+        $this->assertSame('\'mongodump\' --db dbname --archive --host localhost --port 27017 > "/save/to/new (directory)/dbname.gz"', $dumpCommand);
     }
 
     /** @test */

--- a/tests/MongoDbTest.php
+++ b/tests/MongoDbTest.php
@@ -42,8 +42,9 @@ class MongoDbTest extends TestCase
             ->enableCompression()
             ->getDumpCommand('dbname.gz');
 
-        $this->assertSame('\'mongodump\' --db dbname'
-            .' --archive --host localhost --port 27017 | gzip > "dbname.gz"', $dumpCommand);
+        $this->assertSame('if output=$(\'mongodump\' --db dbname --archive --host localhost --port 27017); then
+  echo "$output" | gzip > "dbname.gz"
+fi', $dumpCommand);
     }
 
     /** @test */
@@ -54,8 +55,9 @@ class MongoDbTest extends TestCase
             ->useCompressor(new GzipCompressor)
             ->getDumpCommand('dbname.gz');
 
-        $this->assertSame('\'mongodump\' --db dbname'
-            .' --archive --host localhost --port 27017 | gzip > "dbname.gz"', $dumpCommand);
+        $this->assertSame('if output=$(\'mongodump\' --db dbname --archive --host localhost --port 27017); then
+  echo "$output" | gzip > "dbname.gz"
+fi', $dumpCommand);
     }
 
     /** @test */
@@ -66,8 +68,9 @@ class MongoDbTest extends TestCase
             ->useCompressor(new GzipCompressor)
             ->getDumpCommand('/save/to/new (directory)/dbname.gz');
 
-        $this->assertSame('\'mongodump\' --db dbname'
-            .' --archive --host localhost --port 27017 | gzip > "/save/to/new (directory)/dbname.gz"', $dumpCommand);
+        $this->assertSame('if output=$(\'mongodump\' --db dbname --archive --host localhost --port 27017); then
+  echo "$output" | gzip > "/save/to/new (directory)/dbname.gz"
+fi', $dumpCommand);
     }
 
     /** @test */

--- a/tests/MySqlTest.php
+++ b/tests/MySqlTest.php
@@ -46,8 +46,12 @@ class MySqlTest extends TestCase
             ->enableCompression()
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('if output=$(\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname); then
+        $this->assertSame('if output=$(\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname);
+then
   echo "$output" | gzip > "dump.sql"
+else
+  echo "Dump was not succesful." >&2
+  exit 1
 fi', $dumpCommand);
     }
 
@@ -61,8 +65,12 @@ fi', $dumpCommand);
             ->useCompressor(new GzipCompressor)
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('if output=$(\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname); then
+        $this->assertSame('if output=$(\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname);
+then
   echo "$output" | gzip > "dump.sql"
+else
+  echo "Dump was not succesful." >&2
+  exit 1
 fi', $dumpCommand);
     }
 
@@ -76,8 +84,12 @@ fi', $dumpCommand);
             ->useCompressor(new GzipCompressor())
             ->getDumpCommand('/save/to/new (directory)/dump.sql', 'credentials.txt');
 
-        $this->assertSame('if output=$(\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname); then
+        $this->assertSame('if output=$(\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname);
+then
   echo "$output" | gzip > "/save/to/new (directory)/dump.sql"
+else
+  echo "Dump was not succesful." >&2
+  exit 1
 fi', $dumpCommand);
     }
 

--- a/tests/MySqlTest.php
+++ b/tests/MySqlTest.php
@@ -46,7 +46,9 @@ class MySqlTest extends TestCase
             ->enableCompression()
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname | gzip > "dump.sql"', $dumpCommand);
+        $this->assertSame('if output=$(\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname); then
+  echo "$output" | gzip > "dump.sql"
+fi', $dumpCommand);
     }
 
     /** @test */
@@ -59,7 +61,9 @@ class MySqlTest extends TestCase
             ->useCompressor(new GzipCompressor)
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname | gzip > "dump.sql"', $dumpCommand);
+        $this->assertSame('if output=$(\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname); then
+  echo "$output" | gzip > "dump.sql"
+fi', $dumpCommand);
     }
 
     /** @test */
@@ -72,7 +76,9 @@ class MySqlTest extends TestCase
             ->useCompressor(new GzipCompressor())
             ->getDumpCommand('/save/to/new (directory)/dump.sql', 'credentials.txt');
 
-        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname | gzip > "/save/to/new (directory)/dump.sql"', $dumpCommand);
+        $this->assertSame('if output=$(\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname); then
+  echo "$output" | gzip > "/save/to/new (directory)/dump.sql"
+fi', $dumpCommand);
     }
 
     /** @test */

--- a/tests/MySqlTest.php
+++ b/tests/MySqlTest.php
@@ -81,16 +81,9 @@ fi', $dumpCommand);
             ->setDbName('dbname')
             ->setUserName('username')
             ->setPassword('password')
-            ->useCompressor(new GzipCompressor())
             ->getDumpCommand('/save/to/new (directory)/dump.sql', 'credentials.txt');
 
-        $this->assertSame('if output=$(\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname);
-then
-  echo "$output" | gzip > "/save/to/new (directory)/dump.sql"
-else
-  echo "Dump was not succesful." >&2
-  exit 1
-fi', $dumpCommand);
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname > "/save/to/new (directory)/dump.sql"', $dumpCommand);
     }
 
     /** @test */

--- a/tests/PostgreSqlTest.php
+++ b/tests/PostgreSqlTest.php
@@ -46,8 +46,12 @@ class PostgreSqlTest extends TestCase
             ->enableCompression()
             ->getDumpCommand('dump.sql');
 
-        $this->assertSame('if output=$(\'pg_dump\' -U username -h localhost -p 5432); then
+        $this->assertSame('if output=$(\'pg_dump\' -U username -h localhost -p 5432);
+then
   echo "$output" | gzip > "dump.sql"
+else
+  echo "Dump was not succesful." >&2
+  exit 1
 fi', $dumpCommand);
     }
 
@@ -61,8 +65,12 @@ fi', $dumpCommand);
             ->useCompressor(new GzipCompressor)
             ->getDumpCommand('dump.sql');
 
-        $this->assertSame('if output=$(\'pg_dump\' -U username -h localhost -p 5432); then
+        $this->assertSame('if output=$(\'pg_dump\' -U username -h localhost -p 5432);
+then
   echo "$output" | gzip > "dump.sql"
+else
+  echo "Dump was not succesful." >&2
+  exit 1
 fi', $dumpCommand);
     }
 
@@ -76,8 +84,12 @@ fi', $dumpCommand);
             ->useCompressor(new GzipCompressor)
             ->getDumpCommand('/save/to/new (directory)/dump.sql');
 
-        $this->assertSame('if output=$(\'pg_dump\' -U username -h localhost -p 5432); then
+        $this->assertSame('if output=$(\'pg_dump\' -U username -h localhost -p 5432);
+then
   echo "$output" | gzip > "/save/to/new (directory)/dump.sql"
+else
+  echo "Dump was not succesful." >&2
+  exit 1
 fi', $dumpCommand);
     }
 

--- a/tests/PostgreSqlTest.php
+++ b/tests/PostgreSqlTest.php
@@ -81,16 +81,9 @@ fi', $dumpCommand);
             ->setDbName('dbname')
             ->setUserName('username')
             ->setPassword('password')
-            ->useCompressor(new GzipCompressor)
             ->getDumpCommand('/save/to/new (directory)/dump.sql');
 
-        $this->assertSame('if output=$(\'pg_dump\' -U username -h localhost -p 5432);
-then
-  echo "$output" | gzip > "/save/to/new (directory)/dump.sql"
-else
-  echo "Dump was not succesful." >&2
-  exit 1
-fi', $dumpCommand);
+        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 > "/save/to/new (directory)/dump.sql"', $dumpCommand);
     }
 
     /** @test */

--- a/tests/PostgreSqlTest.php
+++ b/tests/PostgreSqlTest.php
@@ -46,7 +46,9 @@ class PostgreSqlTest extends TestCase
             ->enableCompression()
             ->getDumpCommand('dump.sql');
 
-        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 | gzip > "dump.sql"', $dumpCommand);
+        $this->assertSame('if output=$(\'pg_dump\' -U username -h localhost -p 5432); then
+  echo "$output" | gzip > "dump.sql"
+fi', $dumpCommand);
     }
 
     /** @test */
@@ -59,7 +61,9 @@ class PostgreSqlTest extends TestCase
             ->useCompressor(new GzipCompressor)
             ->getDumpCommand('dump.sql');
 
-        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 | gzip > "dump.sql"', $dumpCommand);
+        $this->assertSame('if output=$(\'pg_dump\' -U username -h localhost -p 5432); then
+  echo "$output" | gzip > "dump.sql"
+fi', $dumpCommand);
     }
 
     /** @test */
@@ -72,7 +76,9 @@ class PostgreSqlTest extends TestCase
             ->useCompressor(new GzipCompressor)
             ->getDumpCommand('/save/to/new (directory)/dump.sql');
 
-        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 | gzip > "/save/to/new (directory)/dump.sql"', $dumpCommand);
+        $this->assertSame('if output=$(\'pg_dump\' -U username -h localhost -p 5432); then
+  echo "$output" | gzip > "/save/to/new (directory)/dump.sql"
+fi', $dumpCommand);
     }
 
     /** @test */

--- a/tests/SqliteTest.php
+++ b/tests/SqliteTest.php
@@ -34,7 +34,10 @@ class SqliteTest extends TestCase
             ->enableCompression()
             ->getDumpCommand('dump.sql');
 
-        $expected = "echo 'BEGIN IMMEDIATE;\n.dump' | 'sqlite3' --bail 'dbname.sqlite' | gzip > \"dump.sql\"";
+        $expected = 'if output=$(echo \'BEGIN IMMEDIATE;
+.dump\' | \'sqlite3\' --bail \'dbname.sqlite\'); then
+  echo "$output" | gzip > "dump.sql"
+fi';
 
         $this->assertEquals($expected, $dumpCommand);
     }
@@ -47,7 +50,10 @@ class SqliteTest extends TestCase
             ->useCompressor(new GzipCompressor)
             ->getDumpCommand('dump.sql');
 
-        $expected = "echo 'BEGIN IMMEDIATE;\n.dump' | 'sqlite3' --bail 'dbname.sqlite' | gzip > \"dump.sql\"";
+        $expected = 'if output=$(echo \'BEGIN IMMEDIATE;
+.dump\' | \'sqlite3\' --bail \'dbname.sqlite\'); then
+  echo "$output" | gzip > "dump.sql"
+fi';
 
         $this->assertEquals($expected, $dumpCommand);
     }

--- a/tests/SqliteTest.php
+++ b/tests/SqliteTest.php
@@ -35,8 +35,12 @@ class SqliteTest extends TestCase
             ->getDumpCommand('dump.sql');
 
         $expected = 'if output=$(echo \'BEGIN IMMEDIATE;
-.dump\' | \'sqlite3\' --bail \'dbname.sqlite\'); then
+.dump\' | \'sqlite3\' --bail \'dbname.sqlite\');
+then
   echo "$output" | gzip > "dump.sql"
+else
+  echo "Dump was not succesful." >&2
+  exit 1
 fi';
 
         $this->assertEquals($expected, $dumpCommand);
@@ -51,8 +55,12 @@ fi';
             ->getDumpCommand('dump.sql');
 
         $expected = 'if output=$(echo \'BEGIN IMMEDIATE;
-.dump\' | \'sqlite3\' --bail \'dbname.sqlite\'); then
+.dump\' | \'sqlite3\' --bail \'dbname.sqlite\');
+then
   echo "$output" | gzip > "dump.sql"
+else
+  echo "Dump was not succesful." >&2
+  exit 1
 fi';
 
         $this->assertEquals($expected, $dumpCommand);


### PR DESCRIPTION
This wraps the dump command in an if, for example:

```
if output=$('mysqldump' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname);
then
  echo "$output" | gzip > "/save/to/new (directory)/dump.sql"
else
  echo "Dump was not succesful." >&2
  exit 1
fi
```

If the dump command fails for some reason, it will output the right exit code and no dump will be created.