### PR TITLE
remove indented for BASH Identifier

### DIFF
--- a/src/DbDumper.php
+++ b/src/DbDumper.php
@@ -270,7 +270,7 @@ abstract class DbDumper
               echo "Dump was not succesful." >&2
               exit 1
             fi
-            BASH;
+BASH;
         }
 
         return $command.' > '.$dumpFile;


### PR DESCRIPTION
continue #100 

Hi, I am using Laravel 5.7.28 and just required this package, but now facing the following error:

<img width="300" alt="Screenshot 2019-05-30 at 9 32 14 PM" src="https://user-images.githubusercontent.com/25523465/58636254-76657c80-8322-11e9-9698-80bd2624f555.png">

and found that the `BASH` Identifier was indented in `DbDumper.php`

based on <a href="https://www.php.net/manual/en/language.types.string.php#language.types.string.syntax.heredoc" target="_blank">php.net</a>, the Identifier must not be indented, right?

https://github.com/spatie/db-dumper/blob/96010c687ae9102524ddf3ed4b98ab7b625141bf/src/DbDumper.php#L273

And this is the problem which causes this error, right?
