### PR TITLE
Remove indent for endblock heredoc

### DIFF
--- a/src/DbDumper.php
+++ b/src/DbDumper.php
@@ -270,7 +270,7 @@ abstract class DbDumper
               echo "Dump was not succesful." >&2
               exit 1
             fi
-            BASH;
+BASH;
         }
 
         return $command.' > '.$dumpFile;


### PR DESCRIPTION
When I test your library on my production server, I've a syntax error :

```
$ php -l vendor/spatie/db-dumper/src/DbDumper.php 
PHP Parse error:  syntax error, unexpected end of file in vendor/spatie/db-dumper/src/DbDumper.php on line 279
Errors parsing vendor/spatie/db-dumper/src/DbDumper.php