### PR TITLE
Fix for memory leak (issue #109)

### DIFF
--- a/src/DbDumper.php
+++ b/src/DbDumper.php
@@ -262,15 +262,7 @@ abstract class DbDumper
         if ($this->compressor) {
             $compressCommand = $this->compressor->useCommand();
 
-            return <<<BASH
-            if output=\$({$command});
-            then
-              echo "\$output" | $compressCommand > $dumpFile
-            else
-              echo "Dump was not succesful." >&2
-              exit 1
-            fi
-            BASH;
+            return "(((({$command}; echo \$? >&3) | {$compressCommand} > {$dumpFile}) 3>&1) | (read x; exit \$x))";
         }
 
         return $command.' > '.$dumpFile;

--- a/tests/MongoDbTest.php
+++ b/tests/MongoDbTest.php
@@ -42,13 +42,9 @@ class MongoDbTest extends TestCase
             ->enableCompression()
             ->getDumpCommand('dbname.gz');
 
-        $this->assertSame('if output=$(\'mongodump\' --db dbname --archive --host localhost --port 27017);
-then
-  echo "$output" | gzip > "dbname.gz"
-else
-  echo "Dump was not succesful." >&2
-  exit 1
-fi', $dumpCommand);
+        $expected = '((((\'mongodump\' --db dbname --archive --host localhost --port 27017; echo $? >&3) | gzip > "dbname.gz") 3>&1) | (read x; exit $x))';
+
+        $this->assertSame($expected, $dumpCommand);
     }
 
     /** @test */
@@ -59,13 +55,9 @@ fi', $dumpCommand);
             ->useCompressor(new GzipCompressor)
             ->getDumpCommand('dbname.gz');
 
-        $this->assertSame('if output=$(\'mongodump\' --db dbname --archive --host localhost --port 27017);
-then
-  echo "$output" | gzip > "dbname.gz"
-else
-  echo "Dump was not succesful." >&2
-  exit 1
-fi', $dumpCommand);
+        $expected = '((((\'mongodump\' --db dbname --archive --host localhost --port 27017; echo $? >&3) | gzip > "dbname.gz") 3>&1) | (read x; exit $x))';
+
+        $this->assertSame($expected, $dumpCommand);
     }
 
     /** @test */

--- a/tests/MySqlTest.php
+++ b/tests/MySqlTest.php
@@ -46,13 +46,9 @@ class MySqlTest extends TestCase
             ->enableCompression()
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('if output=$(\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname);
-then
-  echo "$output" | gzip > "dump.sql"
-else
-  echo "Dump was not succesful." >&2
-  exit 1
-fi', $dumpCommand);
+        $expected = '((((\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname; echo $? >&3) | gzip > "dump.sql") 3>&1) | (read x; exit $x))';
+
+        $this->assertSame($expected, $dumpCommand);
     }
 
     /** @test */
@@ -65,13 +61,9 @@ fi', $dumpCommand);
             ->useCompressor(new GzipCompressor)
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
-        $this->assertSame('if output=$(\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname);
-then
-  echo "$output" | gzip > "dump.sql"
-else
-  echo "Dump was not succesful." >&2
-  exit 1
-fi', $dumpCommand);
+        $expected = '((((\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname; echo $? >&3) | gzip > "dump.sql") 3>&1) | (read x; exit $x))';
+
+        $this->assertSame($expected, $dumpCommand);
     }
 
     /** @test */

--- a/tests/PostgreSqlTest.php
+++ b/tests/PostgreSqlTest.php
@@ -46,13 +46,9 @@ class PostgreSqlTest extends TestCase
             ->enableCompression()
             ->getDumpCommand('dump.sql');
 
-        $this->assertSame('if output=$(\'pg_dump\' -U username -h localhost -p 5432);
-then
-  echo "$output" | gzip > "dump.sql"
-else
-  echo "Dump was not succesful." >&2
-  exit 1
-fi', $dumpCommand);
+        $expected = '((((\'pg_dump\' -U username -h localhost -p 5432; echo $? >&3) | gzip > "dump.sql") 3>&1) | (read x; exit $x))';
+
+        $this->assertSame($expected, $dumpCommand);
     }
 
     /** @test */
@@ -65,13 +61,9 @@ fi', $dumpCommand);
             ->useCompressor(new GzipCompressor)
             ->getDumpCommand('dump.sql');
 
-        $this->assertSame('if output=$(\'pg_dump\' -U username -h localhost -p 5432);
-then
-  echo "$output" | gzip > "dump.sql"
-else
-  echo "Dump was not succesful." >&2
-  exit 1
-fi', $dumpCommand);
+        $expected = '((((\'pg_dump\' -U username -h localhost -p 5432; echo $? >&3) | gzip > "dump.sql") 3>&1) | (read x; exit $x))';
+
+        $this->assertSame($expected, $dumpCommand);
     }
 
     /** @test */

--- a/tests/SqliteTest.php
+++ b/tests/SqliteTest.php
@@ -34,14 +34,8 @@ class SqliteTest extends TestCase
             ->enableCompression()
             ->getDumpCommand('dump.sql');
 
-        $expected = 'if output=$(echo \'BEGIN IMMEDIATE;
-.dump\' | \'sqlite3\' --bail \'dbname.sqlite\');
-then
-  echo "$output" | gzip > "dump.sql"
-else
-  echo "Dump was not succesful." >&2
-  exit 1
-fi';
+        $expected = '((((echo \'BEGIN IMMEDIATE;
+.dump\' | \'sqlite3\' --bail \'dbname.sqlite\'; echo $? >&3) | gzip > "dump.sql") 3>&1) | (read x; exit $x))';
 
         $this->assertEquals($expected, $dumpCommand);
     }
@@ -54,14 +48,8 @@ fi';
             ->useCompressor(new GzipCompressor)
             ->getDumpCommand('dump.sql');
 
-        $expected = 'if output=$(echo \'BEGIN IMMEDIATE;
-.dump\' | \'sqlite3\' --bail \'dbname.sqlite\');
-then
-  echo "$output" | gzip > "dump.sql"
-else
-  echo "Dump was not succesful." >&2
-  exit 1
-fi';
+        $expected = '((((echo \'BEGIN IMMEDIATE;
+.dump\' | \'sqlite3\' --bail \'dbname.sqlite\'; echo $? >&3) | gzip > "dump.sql") 3>&1) | (read x; exit $x))';
 
         $this->assertEquals($expected, $dumpCommand);
     }
@@ -100,6 +88,7 @@ fi';
 
         Sqlite::create()
             ->setDbName($dbPath)
+            ->useCompressor(new GzipCompressor)
             ->dumpToFile($dbBackupPath);
 
         $this->assertFileExists($dbBackupPath);


### PR DESCRIPTION
Fix for https://github.com/spatie/db-dumper/issues/109

Redirects the dumps exit code to file descriptor 3, so the command can exit with that code at the end.

This allows us to stream the dumps stdout directly to gzip, while catching any errors generated by the dump executable. 

POSIX compliant. Tested with dash and bash on Debian and Ubuntu.

(Since the bash heredoc is no longer used, minimum requirement for PHP could be lowered to 7.2)