### PR TITLE
fixed issue when pg_dump process failed to start on Windows

### DIFF
--- a/src/Databases/PostgreSql.php
+++ b/src/Databases/PostgreSql.php
@@ -114,8 +114,11 @@ class PostgreSql extends DbDumper
 
     protected function getEnvironmentVariablesForDumpCommand(string $temporaryCredentialsFile): array
     {
-        $filter = function ($key) { return in_array($key, ['Path', 'SystemRoot']); };
+        $filter = function ($key) {
+            return in_array($key, ['Path', 'SystemRoot']);
+        };
         $systemVariables = array_filter($_ENV, $filter, ARRAY_FILTER_USE_KEY);
+
         return array_merge($systemVariables, [
             'PGPASSFILE' => $temporaryCredentialsFile,
             'PGDATABASE' => $this->dbName,

--- a/src/Databases/PostgreSql.php
+++ b/src/Databases/PostgreSql.php
@@ -114,9 +114,11 @@ class PostgreSql extends DbDumper
 
     protected function getEnvironmentVariablesForDumpCommand(string $temporaryCredentialsFile): array
     {
-        return [
+        $filter = function ($key) { return in_array($key, ['Path', 'SystemRoot']); };
+        $systemVariables = array_filter($_ENV, $filter, ARRAY_FILTER_USE_KEY);
+        return array_merge($systemVariables, [
             'PGPASSFILE' => $temporaryCredentialsFile,
             'PGDATABASE' => $this->dbName,
-        ];
+        ]);
     }
 }


### PR DESCRIPTION
Hello!

This commit fixes issue with starting pg_dump process on Windows.

When function Process::fromShellCommandline() starting process with $envVars array it will start process with only these variables and ignore system ones.

Because of that PHP function proc_open() cant find pg_dump executable from PATH variable and failed to start it.

I added a Windows Path variable, to solve that.

Also i added SystemRoot variable for basic Windows environment. Without it pg_dump cannot establish socket connection with database.

Please accept this pull request.