### PR TITLE
sqlite3 database dump enabled on windows.

### DIFF
--- a/src/Databases/Sqlite.php
+++ b/src/Databases/Sqlite.php
@@ -34,8 +34,14 @@ class Sqlite extends DbDumper
      */
     public function getDumpCommand(string $dumpFile): string
     {
+        $dumpInSqlite = "echo 'BEGIN IMMEDIATE;\n.dump'";
+        if ($this->isWindows()) {
+            $dumpInSqlite = "(echo BEGIN IMMEDIATE; & echo .dump)";
+        }
+        $quote = $this->determineQuote();
+
         $command = sprintf(
-            "echo 'BEGIN IMMEDIATE;\n.dump' | '%ssqlite3' --bail '%s'",
+            "{$dumpInSqlite} | {$quote}%ssqlite3{$quote} --bail {$quote}%s{$quote}",
             $this->dumpBinaryPath,
             $this->dbName
         );

--- a/src/DbDumper.php
+++ b/src/DbDumper.php
@@ -272,4 +272,9 @@ abstract class DbDumper
     {
         return strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' ? '"' : "'";
     }
+
+    protected function isWindows(): string
+    {
+        return strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' ? true : false;
+    }
 }


### PR DESCRIPTION
On Windows, backup of sqlite database is failed.

- Because the specification of `echo` is different from UNIX.
- Because the path quote is different from UNIX.

I changed it to succeed by switching commands in Windows.

Please merge if you like.

If you merge this, I try PR to that the larabel-backup's composer.json upadte.