### PR TITLE
Added doNotCreateTables to Postgres driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 composer.lock
 docs
 vendor
+.phpunit.result.cache

--- a/src/Databases/PostgreSql.php
+++ b/src/Databases/PostgreSql.php
@@ -70,7 +70,7 @@ class PostgreSql extends DbDumper
         $command = [
             "{$quote}{$this->dumpBinaryPath}pg_dump{$quote}",
             "-U {$this->userName}",
-            '-h ' . ($this->socket === '' ? $this->host : $this->socket),
+            '-h '.($this->socket === '' ? $this->host : $this->socket),
             "-p {$this->port}",
         ];
 
@@ -78,7 +78,7 @@ class PostgreSql extends DbDumper
             $command[] = '--inserts';
         }
 
-        if (!$this->createTables) {
+        if (! $this->createTables) {
             $command[] = '--data-only';
         }
 
@@ -86,12 +86,12 @@ class PostgreSql extends DbDumper
             $command[] = $extraOption;
         }
 
-        if (!empty($this->includeTables)) {
-            $command[] = '-t ' . implode(' -t ', $this->includeTables);
+        if (! empty($this->includeTables)) {
+            $command[] = '-t '.implode(' -t ', $this->includeTables);
         }
 
-        if (!empty($this->excludeTables)) {
-            $command[] = '-T ' . implode(' -T ', $this->excludeTables);
+        if (! empty($this->excludeTables)) {
+            $command[] = '-T '.implode(' -T ', $this->excludeTables);
         }
 
         return $this->echoToFile(implode(' ', $command), $dumpFile);

--- a/src/Databases/PostgreSql.php
+++ b/src/Databases/PostgreSql.php
@@ -3,13 +3,16 @@
 namespace Spatie\DbDumper\Databases;
 
 use Spatie\DbDumper\DbDumper;
-use Symfony\Component\Process\Process;
 use Spatie\DbDumper\Exceptions\CannotStartDump;
+use Symfony\Component\Process\Process;
 
 class PostgreSql extends DbDumper
 {
     /** @var bool */
     protected $useInserts = false;
+
+    /** @var bool */
+    protected $createTables = true;
 
     public function __construct()
     {
@@ -67,7 +70,7 @@ class PostgreSql extends DbDumper
         $command = [
             "{$quote}{$this->dumpBinaryPath}pg_dump{$quote}",
             "-U {$this->userName}",
-            '-h '.($this->socket === '' ? $this->host : $this->socket),
+            '-h ' . ($this->socket === '' ? $this->host : $this->socket),
             "-p {$this->port}",
         ];
 
@@ -75,16 +78,20 @@ class PostgreSql extends DbDumper
             $command[] = '--inserts';
         }
 
+        if (!$this->createTables) {
+            $command[] = '--data-only';
+        }
+
         foreach ($this->extraOptions as $extraOption) {
             $command[] = $extraOption;
         }
 
-        if (! empty($this->includeTables)) {
-            $command[] = '-t '.implode(' -t ', $this->includeTables);
+        if (!empty($this->includeTables)) {
+            $command[] = '-t ' . implode(' -t ', $this->includeTables);
         }
 
-        if (! empty($this->excludeTables)) {
-            $command[] = '-T '.implode(' -T ', $this->excludeTables);
+        if (!empty($this->excludeTables)) {
+            $command[] = '-T ' . implode(' -T ', $this->excludeTables);
         }
 
         return $this->echoToFile(implode(' ', $command), $dumpFile);
@@ -118,5 +125,15 @@ class PostgreSql extends DbDumper
             'PGPASSFILE' => $temporaryCredentialsFile,
             'PGDATABASE' => $this->dbName,
         ];
+    }
+
+    /**
+     * @return $this
+     */
+    public function doNotCreateTables()
+    {
+        $this->createTables = false;
+
+        return $this;
     }
 }

--- a/tests/PostgreSqlTest.php
+++ b/tests/PostgreSqlTest.php
@@ -3,10 +3,10 @@
 namespace Spatie\DbDumper\Test;
 
 use PHPUnit\Framework\TestCase;
-use Spatie\DbDumper\Databases\PostgreSql;
 use Spatie\DbDumper\Compressors\GzipCompressor;
-use Spatie\DbDumper\Exceptions\CannotStartDump;
+use Spatie\DbDumper\Databases\PostgreSql;
 use Spatie\DbDumper\Exceptions\CannotSetParameter;
+use Spatie\DbDumper\Exceptions\CannotStartDump;
 
 class PostgreSqlTest extends TestCase
 {
@@ -251,5 +251,18 @@ class PostgreSqlTest extends TestCase
         $dumper = PostgreSql::create()->setHost('myHost');
 
         $this->assertEquals('myHost', $dumper->getHost());
+    }
+
+    /** @test */
+    public function it_can_generate_a_dump_command_with_no_create_info()
+    {
+        $dumpCommand = PostgreSql::create()
+            ->setDbName('dbname')
+            ->setUserName('username')
+            ->setPassword('password')
+            ->doNotCreateTables()
+            ->getDumpCommand('dump.sql', 'credentials.txt');
+
+        $this->assertSame('\'pg_dump\' -U username -h localhost -p 5432 --data-only > "dump.sql"', $dumpCommand);
     }
 }


### PR DESCRIPTION
Noticed that the doNotCreateTables method was not available for Postgres. Added it along with a passing test.