### PR TITLE
Fix thrown exception

### DIFF
--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -308,7 +308,7 @@ class MySql extends DbDumper
         }
 
         if (strlen('dbName') === 0 && ! $this->allDatabasesWasSetAsExtraOption) {
-            throw CannotStartDump::emptyParameter($requiredProperty);
+            throw CannotStartDump::emptyParameter('dbName');
         }
     }
 }


### PR DESCRIPTION
If this was left the way it was, it would falsely report that "Parameter host cannot be empty." even though the tested parameter was `dbName`.