### PR TITLE
Allow for adding options after the db name

### DIFF
--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -283,6 +283,10 @@ class MySql extends DbDumper
             $command[] = "--tables {$includeTables}";
         }
 
+        foreach ($this->extraOptionsAtEnd as $extraOptionAtEnd) {
+            $command[] = $extraOptionAtEnd;
+        }
+
         return $this->echoToFile(implode(' ', $command), $dumpFile);
     }
 

--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -283,8 +283,8 @@ class MySql extends DbDumper
             $command[] = "--tables {$includeTables}";
         }
 
-        foreach ($this->extraOptionsAtEnd as $extraOptionAtEnd) {
-            $command[] = $extraOptionAtEnd;
+        foreach ($this->extraOptionsAfterDbName as $extraOptionAfterDbName) {
+            $command[] = $extraOptionAfterDbName;
         }
 
         return $this->echoToFile(implode(' ', $command), $dumpFile);

--- a/src/DbDumper.php
+++ b/src/DbDumper.php
@@ -43,6 +43,9 @@ abstract class DbDumper
     /** @var array */
     protected $extraOptions = [];
 
+    /** @var array */
+    protected $extraOptionsAtEnd = [];
+
     /** @var object */
     protected $compressor = null;
 
@@ -233,6 +236,20 @@ abstract class DbDumper
     {
         if (! empty($extraOption)) {
             $this->extraOptions[] = $extraOption;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param string $extraOptionAtEnd
+     *
+     * @return $this
+     */
+    public function addExtraOptionAtEnd(string $extraOptionAtEnd)
+    {
+        if (! empty($extraOptionAtEnd)) {
+            $this->extraOptionsAtEnd[] = $extraOptionAtEnd;
         }
 
         return $this;

--- a/src/DbDumper.php
+++ b/src/DbDumper.php
@@ -44,7 +44,7 @@ abstract class DbDumper
     protected $extraOptions = [];
 
     /** @var array */
-    protected $extraOptionsAtEnd = [];
+    protected $extraOptionsAfterDbName = [];
 
     /** @var object */
     protected $compressor = null;
@@ -246,10 +246,10 @@ abstract class DbDumper
      *
      * @return $this
      */
-    public function addExtraOptionAtEnd(string $extraOptionAtEnd)
+    public function addExtraOptionAfterDbName(string $extraOptionAfterDbName)
     {
-        if (! empty($extraOptionAtEnd)) {
-            $this->extraOptionsAtEnd[] = $extraOptionAtEnd;
+        if (! empty($extraOptionAfterDbName)) {
+            $this->extraOptionsAfterDbName[] = $extraOptionAfterDbName;
         }
 
         return $this;

--- a/tests/MySqlTest.php
+++ b/tests/MySqlTest.php
@@ -302,7 +302,7 @@ class MySqlTest extends TestCase
         $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --extra-option --another-extra-option="value" dbname > "dump.sql"', $dumpCommand);
     }
 
-        /** @test */
+    /** @test */
     public function it_can_add_extra_options_after_db_name()
     {
         $dumpCommand = MySql::create()

--- a/tests/MySqlTest.php
+++ b/tests/MySqlTest.php
@@ -92,7 +92,7 @@ class MySqlTest extends TestCase
     }
 
     /** @test */
-    public function it_can_generate_a_dump_command_without_using_extended_insterts()
+    public function it_can_generate_a_dump_command_without_using_extended_inserts()
     {
         $dumpCommand = MySql::create()
             ->setDbName('dbname')
@@ -300,6 +300,20 @@ class MySqlTest extends TestCase
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
         $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --extra-option --another-extra-option="value" dbname > "dump.sql"', $dumpCommand);
+    }
+
+        /** @test */
+    public function it_can_add_extra_options_after_db_name()
+    {
+        $dumpCommand = MySql::create()
+            ->setDbName('dbname')
+            ->setUserName('username')
+            ->setPassword('password')
+            ->addExtraOption('--extra-option')
+            ->addExtraOptionAtEnd('--another-extra-option="value"')
+            ->getDumpCommand('dump.sql', 'credentials.txt');
+
+        $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --extra-option dbname --another-extra-option="value" > "dump.sql"', $dumpCommand);
     }
 
     /** @test */

--- a/tests/MySqlTest.php
+++ b/tests/MySqlTest.php
@@ -310,7 +310,7 @@ class MySqlTest extends TestCase
             ->setUserName('username')
             ->setPassword('password')
             ->addExtraOption('--extra-option')
-            ->addExtraOptionAtEnd('--another-extra-option="value"')
+            ->addExtraOptionAfterDbName('--another-extra-option="value"')
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
         $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --extra-option dbname --another-extra-option="value" > "dump.sql"', $dumpCommand);


### PR DESCRIPTION
This is useful for being able to use commands such as SED to edit the stream prior to being written to the dump file ie remove auto-increment values