### PR TITLE
Add useColumnStatisticsOff for MySql

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,22 @@ Spatie\DbDumper\Databases\MySql::create()
     ->dumpToFile('dump.sql');
 ```
 
+### Don't use column_statics table with some old version of MySql service.
+
+In order to use "_--column-statistics=0_" as option in mysqldump command you can use _doNotUseColumnStatistics()_ method.
+
+If you have installed _mysqldump 8_, it queries by default _column_statics_ table in _information_schema_ database.
+In some old version of MySql (service) like 5.7, this table it not exists. So you could have an exception during the execution of mysqldump. To avoid this, you could use _doNotUseColumnStatistics()_ method.
+
+```php
+Spatie\DbDumper\Databases\MySql::create()
+    ->setDbName($databaseName)
+    ->setUserName($userName)
+    ->setPassword($password)
+    ->doNotUseColumnStatistics()
+    ->dumpToFile('dump.sql');
+```
+
 ### Excluding tables from the dump
 
 Using an array:

--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -21,7 +21,7 @@ class MySql extends DbDumper
     protected $skipLockTables = false;
 
     /** @var bool */
-    protected $useColumnStatisticsOff = false;
+    protected $doNotUseColumnStatistics = false;
 
     /** @var bool */
     protected $useQuick = false;
@@ -119,9 +119,9 @@ class MySql extends DbDumper
     /**
      * @return $this
      */
-    public function useColumnStatisticsOff()
+    public function doNotUseColumnStatistics()
     {
-        $this->useColumnStatisticsOff = true;
+        $this->doNotUseColumnStatistics = true;
 
         return $this;
     }
@@ -263,7 +263,7 @@ class MySql extends DbDumper
             $command[] = '--skip-lock-tables';
         }
 
-        if ($this->useColumnStatisticsOff) {
+        if ($this->doNotUseColumnStatistics) {
             $command[] = '--column-statistics=0';
         }
 

--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -21,6 +21,9 @@ class MySql extends DbDumper
     protected $skipLockTables = false;
 
     /** @var bool */
+    protected $useColumnStatisticsOff = false;
+
+    /** @var bool */
     protected $useQuick = false;
 
     /** @var string */
@@ -109,6 +112,16 @@ class MySql extends DbDumper
     public function skipLockTables()
     {
         $this->skipLockTables = true;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function useColumnStatisticsOff()
+    {
+        $this->useColumnStatisticsOff = true;
 
         return $this;
     }
@@ -248,6 +261,10 @@ class MySql extends DbDumper
 
         if ($this->skipLockTables) {
             $command[] = '--skip-lock-tables';
+        }
+
+        if ($this->useColumnStatisticsOff) {
+            $command[] = '--column-statistics=0';
         }
 
         if ($this->useQuick) {

--- a/tests/MySqlTest.php
+++ b/tests/MySqlTest.php
@@ -52,6 +52,21 @@ class MySqlTest extends TestCase
     }
 
     /** @test */
+    public function it_can_generate_a_dump_command_with_columnstatistics()
+    {
+        $dumpCommand = MySql::create()
+            ->setDbName('dbname')
+            ->setUserName('username')
+            ->setPassword('password')
+            ->doNotUseColumnStatistics()
+            ->getDumpCommand('dump.sql', 'credentials.txt');
+
+        $expected = '\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --column-statistics=0 dbname > "dump.sql"';
+
+        $this->assertSame($expected, $dumpCommand);
+    }
+
+    /** @test */
     public function it_can_generate_a_dump_command_with_gzip_compressor_enabled()
     {
         $dumpCommand = MySql::create()


### PR DESCRIPTION
Add useColumnStatisticsOff() method in. order to enable --column-statistics=0 useful in a specific case. The scenario is: mysqldump 8 that queries by default column_statics table in information_schema database.
In some old version of MySql (service) like 5.7 , this table not exists.

Close #132