### PR TITLE
Added setHost to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,17 @@ Spatie\DbDumper\Databases\MySql::create()
     ->dumpToFile('dump.sql');
 ```
 
+If your application is deployed and you need to change the host (default is 127.0.0.1), you can add the `setHost()`-function:
+
+```php
+Spatie\DbDumper\Databases\MySql::create()
+    ->setDbName($databaseName)
+    ->setUserName($userName)
+    ->setPassword($password)
+    ->setHost($host)
+    ->dumpToFile('dump.sql');
+```
+
 ### Dump specific tables
 
 Using an array:


### PR DESCRIPTION
I was struggling a little bit to set up my dumper on my deployed application, and I could not find the function setHost in the documentation, so I had to look at the actual file, so I updated the documentation so it explains the setHost function.