### PR TITLE
fix: add some public functions that allow extensibility

### DIFF
--- a/src/Databases/MongoDb.php
+++ b/src/Databases/MongoDb.php
@@ -28,9 +28,7 @@ class MongoDb extends DbDumper
     {
         $this->guardAgainstIncompleteCredentials();
 
-        $command = $this->getDumpCommand($dumpFile);
-
-        $process = Process::fromShellCommandline($command, null, null, null, $this->timeout);
+        $process = $this->getProcess($dumpFile);
 
         $process->run();
 
@@ -118,5 +116,17 @@ class MongoDb extends DbDumper
         }
 
         return $this->echoToFile(implode(' ', $command), $filename);
+    }
+
+    /**
+     * @param string $dumpFile
+     * @return Process
+     */
+    public function getProcess(string $dumpFile): Process
+    {
+        $command = $this->getDumpCommand($dumpFile);
+
+        $process = Process::fromShellCommandline($command, null, null, null, $this->timeout);
+        return $process;
     }
 }

--- a/src/Databases/PostgreSql.php
+++ b/src/Databases/PostgreSql.php
@@ -41,15 +41,7 @@ class PostgreSql extends DbDumper
     {
         $this->guardAgainstIncompleteCredentials();
 
-        $command = $this->getDumpCommand($dumpFile);
-
-        $tempFileHandle = tmpfile();
-        fwrite($tempFileHandle, $this->getContentsOfCredentialsFile());
-        $temporaryCredentialsFile = stream_get_meta_data($tempFileHandle)['uri'];
-
-        $envVars = $this->getEnvironmentVariablesForDumpCommand($temporaryCredentialsFile);
-
-        $process = Process::fromShellCommandline($command, null, $envVars, null, $this->timeout);
+        $process = $this->getProcess($dumpFile);
 
         $process->run();
 
@@ -135,5 +127,23 @@ class PostgreSql extends DbDumper
         $this->createTables = false;
 
         return $this;
+    }
+
+    /**
+     * @param string $dumpFile
+     * @return Process
+     */
+    public function getProcess(string $dumpFile): Process
+    {
+        $command = $this->getDumpCommand($dumpFile);
+
+        $tempFileHandle = tmpfile();
+        fwrite($tempFileHandle, $this->getContentsOfCredentialsFile());
+        $temporaryCredentialsFile = stream_get_meta_data($tempFileHandle)['uri'];
+
+        $envVars = $this->getEnvironmentVariablesForDumpCommand($temporaryCredentialsFile);
+
+        $process = Process::fromShellCommandline($command, null, $envVars, null, $this->timeout);
+        return $process;
     }
 }

--- a/src/Databases/Sqlite.php
+++ b/src/Databases/Sqlite.php
@@ -16,9 +16,7 @@ class Sqlite extends DbDumper
      */
     public function dumpToFile(string $dumpFile)
     {
-        $command = $this->getDumpCommand($dumpFile);
-
-        $process = Process::fromShellCommandline($command, null, null, null, $this->timeout);
+        $process = $this->getProcess($dumpFile);
 
         $process->run();
 
@@ -47,5 +45,17 @@ class Sqlite extends DbDumper
         );
 
         return $this->echoToFile($command, $dumpFile);
+    }
+
+    /**
+     * @param string $dumpFile
+     * @return Process
+     */
+    public function getProcess(string $dumpFile): Process
+    {
+        $command = $this->getDumpCommand($dumpFile);
+
+        $process = Process::fromShellCommandline($command, null, null, null, $this->timeout);
+        return $process;
     }
 }

--- a/src/DbDumper.php
+++ b/src/DbDumper.php
@@ -257,13 +257,13 @@ abstract class DbDumper
 
     abstract public function dumpToFile(string $dumpFile);
 
-    protected function checkIfDumpWasSuccessFul(Process $process, string $outputFile)
+    public function checkIfDumpWasSuccessFul(Process $process, string $outputFile)
     {
-        if (! $process->isSuccessful()) {
+        if ($process->isSuccessful() === false) {
             throw DumpFailed::processDidNotEndSuccessfully($process);
         }
 
-        if (! file_exists($outputFile)) {
+        if (file_exists($outputFile) === false) {
             throw DumpFailed::dumpfileWasNotCreated();
         }
 


### PR DESCRIPTION
I wanted to make this more extensible so I had a way I could get the process back and watch the progress, eg:

```
$process = $this->dumpToFile($mysqlDumper, $outputFile);
$process->start();
$this->output->progressStart();
while ($process->isRunning()) {
            sleep(1);
            clearstatcache(true, $outputFile);
            $size = filesize($outputFile);
            $this->output->progressAdvance($size);
}
$this->output->progressFinish();
```

This means I can now add a progress bar