### PR TITLE
fix: make the process more extensible, avoid touching anything

### DIFF
--- a/src/Databases/MongoDb.php
+++ b/src/Databases/MongoDb.php
@@ -28,9 +28,7 @@ class MongoDb extends DbDumper
     {
         $this->guardAgainstIncompleteCredentials();
 
-        $command = $this->getDumpCommand($dumpFile);
-
-        $process = Process::fromShellCommandline($command, null, null, null, $this->timeout);
+        $process = $this->getProcess($dumpFile);
 
         $process->run();
 
@@ -43,7 +41,7 @@ class MongoDb extends DbDumper
      * @throws \Spatie\DbDumper\Exceptions\CannotStartDump
      * @return void
      */
-    protected function guardAgainstIncompleteCredentials()
+    public function guardAgainstIncompleteCredentials()
     {
         foreach (['dbName', 'host'] as $requiredProperty) {
             if (strlen($this->$requiredProperty) === 0) {
@@ -118,5 +116,16 @@ class MongoDb extends DbDumper
         }
 
         return $this->echoToFile(implode(' ', $command), $filename);
+    }
+
+    /**
+     * @param string $dumpFile
+     * @return Process
+     */
+    public function getProcess(string $dumpFile): Process
+    {
+        $command = $this->getDumpCommand($dumpFile);
+
+        return Process::fromShellCommandline($command, null, null, null, $this->timeout);
     }
 }

--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -190,13 +190,7 @@ class MySql extends DbDumper
     {
         $this->guardAgainstIncompleteCredentials();
 
-        $tempFileHandle = tmpfile();
-        fwrite($tempFileHandle, $this->getContentsOfCredentialsFile());
-        $temporaryCredentialsFile = stream_get_meta_data($tempFileHandle)['uri'];
-
-        $command = $this->getDumpCommand($dumpFile, $temporaryCredentialsFile);
-
-        $process = Process::fromShellCommandline($command, null, null, null, $this->timeout);
+        $process = $this->getProcess($dumpFile);
 
         $process->run();
 
@@ -320,7 +314,7 @@ class MySql extends DbDumper
         return implode(PHP_EOL, $contents);
     }
 
-    protected function guardAgainstIncompleteCredentials()
+    public function guardAgainstIncompleteCredentials()
     {
         foreach (['userName', 'host'] as $requiredProperty) {
             if (strlen($this->$requiredProperty) === 0) {
@@ -331,5 +325,20 @@ class MySql extends DbDumper
         if (strlen($this->dbName) === 0 && ! $this->allDatabasesWasSetAsExtraOption) {
             throw CannotStartDump::emptyParameter('dbName');
         }
+    }
+
+    /**
+     * @param string $dumpFile
+     * @return Process
+     */
+    public function getProcess(string $dumpFile): Process
+    {
+        $tempFileHandle = tmpfile();
+        fwrite($tempFileHandle, $this->getContentsOfCredentialsFile());
+        $temporaryCredentialsFile = stream_get_meta_data($tempFileHandle)['uri'];
+
+        $command = $this->getDumpCommand($dumpFile, $temporaryCredentialsFile);
+
+        return Process::fromShellCommandline($command, null, null, null, $this->timeout);
     }
 }

--- a/src/Databases/PostgreSql.php
+++ b/src/Databases/PostgreSql.php
@@ -41,15 +41,7 @@ class PostgreSql extends DbDumper
     {
         $this->guardAgainstIncompleteCredentials();
 
-        $command = $this->getDumpCommand($dumpFile);
-
-        $tempFileHandle = tmpfile();
-        fwrite($tempFileHandle, $this->getContentsOfCredentialsFile());
-        $temporaryCredentialsFile = stream_get_meta_data($tempFileHandle)['uri'];
-
-        $envVars = $this->getEnvironmentVariablesForDumpCommand($temporaryCredentialsFile);
-
-        $process = Process::fromShellCommandline($command, null, $envVars, null, $this->timeout);
+        $process = $this->getProcess($dumpFile);
 
         $process->run();
 
@@ -110,7 +102,7 @@ class PostgreSql extends DbDumper
         return implode(':', $contents);
     }
 
-    protected function guardAgainstIncompleteCredentials()
+    public function guardAgainstIncompleteCredentials()
     {
         foreach (['userName', 'dbName', 'host'] as $requiredProperty) {
             if (empty($this->$requiredProperty)) {
@@ -135,5 +127,22 @@ class PostgreSql extends DbDumper
         $this->createTables = false;
 
         return $this;
+    }
+
+    /**
+     * @param string $dumpFile
+     * @return Process
+     */
+    public function getProcess(string $dumpFile): Process
+    {
+        $command = $this->getDumpCommand($dumpFile);
+
+        $tempFileHandle = tmpfile();
+        fwrite($tempFileHandle, $this->getContentsOfCredentialsFile());
+        $temporaryCredentialsFile = stream_get_meta_data($tempFileHandle)['uri'];
+
+        $envVars = $this->getEnvironmentVariablesForDumpCommand($temporaryCredentialsFile);
+
+        return Process::fromShellCommandline($command, null, $envVars, null, $this->timeout);
     }
 }

--- a/src/Databases/Sqlite.php
+++ b/src/Databases/Sqlite.php
@@ -16,9 +16,7 @@ class Sqlite extends DbDumper
      */
     public function dumpToFile(string $dumpFile)
     {
-        $command = $this->getDumpCommand($dumpFile);
-
-        $process = Process::fromShellCommandline($command, null, null, null, $this->timeout);
+        $process = $this->getProcess($dumpFile);
 
         $process->run();
 
@@ -47,5 +45,16 @@ class Sqlite extends DbDumper
         );
 
         return $this->echoToFile($command, $dumpFile);
+    }
+
+    /**
+     * @param string $dumpFile
+     * @return Process
+     */
+    public function getProcess(string $dumpFile): Process
+    {
+        $command = $this->getDumpCommand($dumpFile);
+
+        return Process::fromShellCommandline($command, null, null, null, $this->timeout);
     }
 }

--- a/src/DbDumper.php
+++ b/src/DbDumper.php
@@ -257,7 +257,7 @@ abstract class DbDumper
 
     abstract public function dumpToFile(string $dumpFile);
 
-    protected function checkIfDumpWasSuccessFul(Process $process, string $outputFile)
+    public function checkIfDumpWasSuccessFul(Process $process, string $outputFile)
     {
         if (! $process->isSuccessful()) {
             throw DumpFailed::processDidNotEndSuccessfully($process);


### PR DESCRIPTION
I wanted to make this more extensible so I had a way I could get the process back and watch the progress.

Unfortunately I must have changed too much in the last PR which seemed to break a few instances.

I've touched less in this one, literally nothing has changed other than moving logic around and changing the accessibility of methods.

Here's an example of how this can be used:

```
<?php

include '../vendor/autoload.php';

use Spatie\DbDumper\Databases\MySql;

$host = 'test';
$filename = 'example.sql';
$outputFile = $filename;
$host = '127.0.0.1';
$schemaName = 'test';
$userName = 'root';
$password = '';

$mysqlDumper = MySql::create()
    ->setHost($host)
    ->setDbName($schemaName)
    ->setUserName($userName)
    ->setPassword($password)
    ->setGtidPurged('OFF');

$process = $mysqlDumper->getProcess($outputFile);
$process->start();
while ($process->isRunning()) {
    sleep(1);
    clearstatcache(true, $outputFile);
    $size = filesize($outputFile);
    echo $size . PHP_EOL;
}
```

Only, imagine instead of `echo $size`, you replace that with a progress bar, which isn't available in this package.

For example:

```
$process = $mysqlDumper->getProcess($outputFile);
$process->start();
$this->output->progressStart();
while ($process->isRunning()) {
            sleep(1);
            clearstatcache(true, $outputFile);
            $size = filesize($outputFile);
            $this->output->progressAdvance($size);
}
$this->output->progressFinish();
```

Apologise if the previous change had a negative impact, hopefully this doesn't.