### PR TITLE
fix attempt to generate dump over http connection when using socket

### DIFF
--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -313,9 +313,12 @@ class MySql extends DbDumper
             '[client]',
             "user = '{$this->userName}'",
             "password = '{$this->password}'",
-            "host = '{$this->host}'",
             "port = '{$this->port}'",
         ];
+
+        if ($this->socket === '') {
+            $contents[] = "host = '{$this->host}'";
+        }
 
         return implode(PHP_EOL, $contents);
     }

--- a/tests/MySqlTest.php
+++ b/tests/MySqlTest.php
@@ -193,7 +193,7 @@ class MySqlTest extends TestCase
             ->setPassword('password')
             ->setSocket(1234)
             ->getDumpCommand('dump.sql', 'credentials.txt');
-
+        
         $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --socket=1234 dbname > "dump.sql"', $dumpCommand);
     }
 
@@ -278,7 +278,7 @@ class MySqlTest extends TestCase
     }
 
     /** @test */
-    public function it_can_generate_the_contents_of_a_credentials_file()
+    public function it_can_generate_the_contents_of_a_credentials_file_with_a_socket_connetion()
     {
         $credentialsFileContent = MySql::create()
             ->setDbName('dbname')
@@ -289,7 +289,23 @@ class MySqlTest extends TestCase
             ->getContentsOfCredentialsFile();
 
         $this->assertSame(
-            '[client]'.PHP_EOL."user = 'username'".PHP_EOL."password = 'password'".PHP_EOL."host = 'hostname'".PHP_EOL."port = '3306'",
+            '[client]'.PHP_EOL."user = 'username'".PHP_EOL."password = 'password'".PHP_EOL."port = '3306'",
+            $credentialsFileContent
+        );
+    }
+
+    /** @test */
+    public function it_can_generate_the_contents_of_a_credentials_file_with_a_http_connetion()
+    {
+        $credentialsFileContent = MySql::create()
+            ->setDbName('dbname')
+            ->setUserName('username')
+            ->setPassword('password')
+            ->setHost('hostname')
+            ->getContentsOfCredentialsFile();
+
+        $this->assertSame(
+            '[client]'.PHP_EOL."user = 'username'".PHP_EOL."password = 'password'".PHP_EOL."port = '3306'".PHP_EOL."host = 'hostname'",
             $credentialsFileContent
         );
     }


### PR DESCRIPTION
Hi, I run to similar situation like here (https://github.com/spatie/laravel-backup/discussions/1224) where trying to create a backup over a **socket**.

**Error Message** 
Backup failed because The dump process failed with exitcode 2 : Misuse of shell builtins : mysqldump: Got error: 2002: "Can't connect to MySQL server on '127.0.0.1' (115)" when trying to connect.

Since the laravel default **host** ip address for the database is '127.0.0.1' the client prioritizes the http connection from the `credentialsFile` instead of the socket one.

You can find more info about this behavior here: https://bugs.mysql.com/bug.php?id=64703