### PR TITLE
Add PHP 8-only Support (v3)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,31 +2,54 @@
 
 Contributions are **welcome** and will be fully **credited**.
 
-We accept contributions via Pull Requests on [Github](https://github.com/spatie/db-dumper).
+Please read and understand the contribution guide before creating an issue or pull request.
 
+## Etiquette
 
-## Pull Requests
+This project is open source, and as such, the maintainers give their free time to build and maintain the source code
+held within. They make the code freely available in the hope that it will be of use to other developers. It would be
+extremely unfair for them to suffer abuse or anger for their hard work.
 
-- **[PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)** - The easiest way to apply the conventions is to install [PHP Code Sniffer](http://pear.php.net/package/PHP_CodeSniffer).
+Please be considerate towards maintainers when raising issues or presenting pull requests. Let's show the
+world that developers are civilized and selfless people.
+
+It's the duty of the maintainer to ensure that all submissions to the project are of sufficient
+quality to benefit the project. Many developers have different skillsets, strengths, and weaknesses. Respect the maintainer's decision, and do not be upset or abusive if your submission is not used.
+
+## Viability
+
+When requesting or submitting new features, first consider whether it might be useful to others. Open
+source projects are used by many developers, who may have entirely different needs to your own. Think about
+whether or not your feature is likely to be used by other users of the project.
+
+## Procedure
+
+Before filing an issue:
+
+- Attempt to replicate the problem, to ensure that it wasn't a coincidental incident.
+- Check to make sure your feature suggestion isn't already present within the project.
+- Check the pull requests tab to ensure that the bug doesn't have a fix in progress.
+- Check the pull requests tab to ensure that the feature isn't already in progress.
+
+Before submitting a pull request:
+
+- Check the codebase to ensure that your feature doesn't already exist.
+- Check the pull requests to ensure that another person hasn't already submitted the feature or fix.
+
+## Requirements
+
+If the project maintainer has any additional requirements, you will find them listed here.
+
+- **[PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)** - The easiest way to apply the conventions is to install [PHP Code Sniffer](https://pear.php.net/package/PHP_CodeSniffer).
 
 - **Add tests!** - Your patch won't be accepted if it doesn't have tests.
 
 - **Document any change in behaviour** - Make sure the `README.md` and any other relevant documentation are kept up-to-date.
 
-- **Consider our release cycle** - We try to follow [SemVer v2.0.0](http://semver.org/). Randomly breaking public APIs is not an option.
-
-- **Create feature branches** - Don't ask us to pull from your master branch.
+- **Consider our release cycle** - We try to follow [SemVer v2.0.0](https://semver.org/). Randomly breaking public APIs is not an option.
 
 - **One pull request per feature** - If you want to do more than one thing, send multiple pull requests.
 
-- **Send coherent history** - Make sure each individual commit in your pull request is meaningful. If you had to make multiple intermediate commits while developing, please [squash them](http://www.git-scm.com/book/en/v2/Git-Tools-Rewriting-History#Changing-Multiple-Commit-Messages) before submitting.
-
-
-## Running Tests
-
-``` bash
-$ composer test
-```
-
+- **Send coherent history** - Make sure each individual commit in your pull request is meaningful. If you had to make multiple intermediate commits while developing, please [squash them](https://www.git-scm.com/book/en/v2/Git-Tools-Rewriting-History#Changing-Multiple-Commit-Messages) before submitting.
 
 **Happy coding**!

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
 github: spatie
+custom: https://spatie.be/open-source/support-us

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,3 @@
+# Security Policy
+
+If you discover any security related issues, please email freek@spatie.be instead of using the issue tracker.

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,8 +12,7 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                php: [8.0, 7.4, 7.3, 7.2]
-                laravel: [8.*, 7.*, 6.*]
+                php: [8.0]
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `db-dumper` will be documented in this file
 
+## 3.0.0 - unreleased
+
+- require PHP 8+
+- drop all PHP 7.x support
+- use PHP 8 syntax
+- add `Bzip2Compressor` to allow use of the bzip2 compression utility
+
 ## 2.21.1 - 2021-02-24
 
 - fix attempt to generate dump over http connection when using socket (#145)

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ We invest a lot of resources into creating [best in class open source packages](
 We highly appreciate you sending us a postcard from your hometown, mentioning which of our package(s) you are using. You'll find our address on [our contact page](https://spatie.be/about-us). We publish all received postcards on [our virtual postcard wall](https://spatie.be/open-source/postcards).
 
 ## Requirements
+
 For dumping MySQL-db's `mysqldump` should be installed.
 
 For dumping PostgreSQL-db's `pg_dump` should be installed.
@@ -64,6 +65,8 @@ For dumping PostgreSQL-db's `pg_dump` should be installed.
 For dumping SQLite-db's `sqlite3` should be installed.
 
 For dumping MongoDB-db's `mongodump` should be installed.
+
+For compressing dump files, `gzip` and/or `bzip2` should be installed.
 
 ## Installation
 
@@ -224,16 +227,20 @@ $dumpCommand = MySql::create()
 Please note that using the `->addExtraOption('--databases dbname')` or `->addExtraOption('--all-databases')` will override the database name set on a previous `->setDbName()` call.
 
 ### Using compression
-If you want to compress the outputted file, you can use one of the compressors and the resulted dump file will be compressed.
 
-There is one compressor that comes out of the box: `GzipCompressor`. It will compress your db dump with `gzip`. Make sure `gzip` is installed on your system before using this.
+If you want the output file to be compressed, you can use a compressor class.
+
+There are two compressors that come out of the box:
+
+- `GzipCompressor` - This will compress your db dump with `gzip`. Make sure `gzip` is installed on your system before using this.
+- `Bzip2Compressor` - This will compress your db dump with `bzip2`. Make sure `bzip2` is installed on your system before using this.
 
 ```php
 $dumpCommand = MySql::create()
     ->setDbName('dbname')
     ->setUserName('username')
     ->setPassword('password')
-    ->useCompressor(new GzipCompressor())
+    ->useCompressor(new GzipCompressor()) // or `new Bzip2Compressor()`
     ->dumpToFile('dump.sql.gz');
 ```
 

--- a/README.md
+++ b/README.md
@@ -278,23 +278,23 @@ class GzipCompressor implements Compressor
 }
 ```
 
-## Changelog
-
-Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.
-
 ## Testing
 
 ``` bash
-composer test
+$ composer test
 ```
+
+## Changelog
+
+Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.
 
 ## Contributing
 
 Please see [CONTRIBUTING](.github/CONTRIBUTING.md) for details.
 
-## Security
+## Security Vulnerabilities
 
-If you discover any security related issues, please email freek@spatie.be instead of using the issue tracker.
+Please review [our security policy](../../security/policy) on how to report security vulnerabilities.
 
 ## Credits
 

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
         }
     ],
     "require": {
-        "php" : "^7.2|^8.0",
-        "symfony/process": "^4.2|^5.0"
+        "php" : "^8.0",
+        "symfony/process": "^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0|^8.0|^9.0"
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {

--- a/src/Compressors/Bzip2Compressor.php
+++ b/src/Compressors/Bzip2Compressor.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\DbDumper\Compressors;
+
+class Bzip2Compressor implements Compressor
+{
+    public function useCommand(): string
+    {
+        return 'bzip2';
+    }
+
+    public function useExtension(): string
+    {
+        return 'bz2';
+    }
+}

--- a/src/Databases/MongoDb.php
+++ b/src/Databases/MongoDb.php
@@ -8,23 +8,13 @@ use Symfony\Component\Process\Process;
 
 class MongoDb extends DbDumper
 {
-    protected $port = 27017;
+    protected int $port = 27017;
 
-    /** @var null|string */
-    protected $collection = null;
+    protected ?string $collection = null;
 
-    /** @var null|string */
-    protected $authenticationDatabase = null;
+    protected ?string $authenticationDatabase = null;
 
-    /**
-     * Dump the contents of the database to the given file.
-     *
-     * @param string $dumpFile
-     *
-     * @throws \Spatie\DbDumper\Exceptions\CannotStartDump
-     * @throws \Spatie\DbDumper\Exceptions\DumpFailed
-     */
-    public function dumpToFile(string $dumpFile)
+    public function dumpToFile(string $dumpFile): void
     {
         $this->guardAgainstIncompleteCredentials();
 
@@ -39,9 +29,10 @@ class MongoDb extends DbDumper
      * Verifies if the dbname and host options are set.
      *
      * @throws \Spatie\DbDumper\Exceptions\CannotStartDump
+     *
      * @return void
      */
-    public function guardAgainstIncompleteCredentials()
+    public function guardAgainstIncompleteCredentials(): void
     {
         foreach (['dbName', 'host'] as $requiredProperty) {
             if (strlen($this->$requiredProperty) === 0) {
@@ -50,37 +41,20 @@ class MongoDb extends DbDumper
         }
     }
 
-    /**
-     * @param string $collection
-     *
-     * @return \Spatie\DbDumper\Databases\MongoDb
-     */
-    public function setCollection(string $collection)
+    public function setCollection(string $collection): self
     {
         $this->collection = $collection;
 
         return $this;
     }
 
-    /**
-     * @param string $authenticationDatabase
-     *
-     * @return \Spatie\DbDumper\Databases\MongoDb
-     */
-    public function setAuthenticationDatabase(string $authenticationDatabase)
+    public function setAuthenticationDatabase(string $authenticationDatabase): self
     {
         $this->authenticationDatabase = $authenticationDatabase;
 
         return $this;
     }
 
-    /**
-     * Generate the dump command for MongoDb.
-     *
-     * @param string $filename
-     *
-     * @return string
-     */
     public function getDumpCommand(string $filename): string
     {
         $quote = $this->determineQuote();
@@ -118,10 +92,6 @@ class MongoDb extends DbDumper
         return $this->echoToFile(implode(' ', $command), $filename);
     }
 
-    /**
-     * @param string $dumpFile
-     * @return Process
-     */
     public function getProcess(string $dumpFile): Process
     {
         $command = $this->getDumpCommand($dumpFile);

--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -2,44 +2,34 @@
 
 namespace Spatie\DbDumper\Databases;
 
+use phpDocumentor\Reflection\Types\Resource_;
 use Spatie\DbDumper\DbDumper;
 use Spatie\DbDumper\Exceptions\CannotStartDump;
 use Symfony\Component\Process\Process;
 
 class MySql extends DbDumper
 {
-    /** @var bool */
-    protected $skipComments = true;
+    protected bool $skipComments = true;
 
-    /** @var bool */
-    protected $useExtendedInserts = true;
+    protected bool $useExtendedInserts = true;
 
-    /** @var bool */
-    protected $useSingleTransaction = false;
+    protected bool $useSingleTransaction = false;
 
-    /** @var bool */
-    protected $skipLockTables = false;
+    protected bool $skipLockTables = false;
 
-    /** @var bool */
-    protected $doNotUseColumnStatistics = false;
+    protected bool $doNotUseColumnStatistics = false;
 
-    /** @var bool */
-    protected $useQuick = false;
+    protected bool $useQuick = false;
 
-    /** @var string */
-    protected $defaultCharacterSet = '';
+    protected string $defaultCharacterSet = '';
 
-    /** @var bool */
-    protected $dbNameWasSetAsExtraOption = false;
+    protected bool $dbNameWasSetAsExtraOption = false;
 
-    /** @var bool */
-    protected $allDatabasesWasSetAsExtraOption = false;
+    protected bool $allDatabasesWasSetAsExtraOption = false;
 
-    /** @var string */
-    protected $setGtidPurged = 'AUTO';
+    protected string $setGtidPurged = 'AUTO';
 
-    /** @var bool */
-    protected $createTables = true;
+    protected bool $createTables = true;
 
     /** @var false|resource */
     private $tempFileHandle;
@@ -49,147 +39,98 @@ class MySql extends DbDumper
         $this->port = 3306;
     }
 
-    /**
-     * @return $this
-     */
-    public function skipComments()
+    public function skipComments(): self
     {
         $this->skipComments = true;
 
         return $this;
     }
 
-    /**
-     * @return $this
-     */
-    public function dontSkipComments()
+    public function dontSkipComments(): self
     {
         $this->skipComments = false;
 
         return $this;
     }
 
-    /**
-     * @return $this
-     */
-    public function useExtendedInserts()
+    public function useExtendedInserts(): self
     {
         $this->useExtendedInserts = true;
 
         return $this;
     }
 
-    /**
-     * @return $this
-     */
-    public function dontUseExtendedInserts()
+    public function dontUseExtendedInserts(): self
     {
         $this->useExtendedInserts = false;
 
         return $this;
     }
 
-    /**
-     * @return $this
-     */
-    public function useSingleTransaction()
+    public function useSingleTransaction(): self
     {
         $this->useSingleTransaction = true;
 
         return $this;
     }
 
-    /**
-     * @return $this
-     */
-    public function dontUseSingleTransaction()
+    public function dontUseSingleTransaction(): self
     {
         $this->useSingleTransaction = false;
 
         return $this;
     }
 
-    /**
-     * @return $this
-     */
-    public function skipLockTables()
+    public function skipLockTables(): self
     {
         $this->skipLockTables = true;
 
         return $this;
     }
 
-    /**
-     * @return $this
-     */
-    public function doNotUseColumnStatistics()
+    public function doNotUseColumnStatistics(): self
     {
         $this->doNotUseColumnStatistics = true;
 
         return $this;
     }
 
-    /**
-     * @return $this
-     */
-    public function dontSkipLockTables()
+    public function dontSkipLockTables(): self
     {
         $this->skipLockTables = false;
 
         return $this;
     }
 
-    /**
-     * @return $this
-     */
-    public function useQuick()
+    public function useQuick(): self
     {
         $this->useQuick = true;
 
         return $this;
     }
 
-    /**
-     * @return $this
-     */
-    public function dontUseQuick()
+    public function dontUseQuick(): self
     {
         $this->useQuick = false;
 
         return $this;
     }
 
-    /**
-     * @param string $characterSet
-     *
-     * @return $this
-     */
-    public function setDefaultCharacterSet(string $characterSet)
+    public function setDefaultCharacterSet(string $characterSet): self
     {
         $this->defaultCharacterSet = $characterSet;
 
         return $this;
     }
 
-    /**
-     * @return $this
-     */
-    public function setGtidPurged(string $setGtidPurged)
+    public function setGtidPurged(string $setGtidPurged): self
     {
         $this->setGtidPurged = $setGtidPurged;
 
         return $this;
     }
 
-    /**
-     * Dump the contents of the database to the given file.
-     *
-     * @param string $dumpFile
-     *
-     * @throws \Spatie\DbDumper\Exceptions\CannotStartDump
-     * @throws \Spatie\DbDumper\Exceptions\DumpFailed
-     */
-    public function dumpToFile(string $dumpFile)
+    public function dumpToFile(string $dumpFile): void
     {
         $this->guardAgainstIncompleteCredentials();
 
@@ -203,9 +144,9 @@ class MySql extends DbDumper
         $this->checkIfDumpWasSuccessFul($process, $dumpFile);
     }
 
-    public function addExtraOption(string $extraOption)
+    public function addExtraOption(string $extraOption): self
     {
-        if (strpos($extraOption, '--all-databases') !== false) {
+        if (str_contains($extraOption, '--all-databases')) {
             $this->dbNameWasSetAsExtraOption = true;
             $this->allDatabasesWasSetAsExtraOption = true;
         }
@@ -218,24 +159,13 @@ class MySql extends DbDumper
         return parent::addExtraOption($extraOption);
     }
 
-    /**
-     * @return $this
-     */
-    public function doNotCreateTables()
+    public function doNotCreateTables(): self
     {
         $this->createTables = false;
 
         return $this;
     }
 
-    /**
-     * Get the command that should be performed to dump the database.
-     *
-     * @param string $dumpFile
-     * @param string $temporaryCredentialsFile
-     *
-     * @return string
-     */
     public function getDumpCommand(string $dumpFile, string $temporaryCredentialsFile): string
     {
         $quote = $this->determineQuote();
@@ -323,7 +253,7 @@ class MySql extends DbDumper
         return implode(PHP_EOL, $contents);
     }
 
-    public function guardAgainstIncompleteCredentials()
+    public function guardAgainstIncompleteCredentials(): void
     {
         foreach (['userName', 'host'] as $requiredProperty) {
             if (strlen($this->$requiredProperty) === 0) {
@@ -353,7 +283,7 @@ class MySql extends DbDumper
     /**
      * @return false|resource
      */
-    public function getTempFileHandle()
+    public function getTempFileHandle(): mixed
     {
         return $this->tempFileHandle;
     }
@@ -361,7 +291,7 @@ class MySql extends DbDumper
     /**
      * @param false|resource $tempFileHandle
      */
-    public function setTempFileHandle($tempFileHandle)
+    public function setTempFileHandle($tempFileHandle): mixed
     {
         $this->tempFileHandle = $tempFileHandle;
     }

--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\DbDumper\Databases;
 
-use phpDocumentor\Reflection\Types\Resource_;
 use Spatie\DbDumper\DbDumper;
 use Spatie\DbDumper\Exceptions\CannotStartDump;
 use Symfony\Component\Process\Process;

--- a/src/Databases/PostgreSql.php
+++ b/src/Databases/PostgreSql.php
@@ -8,11 +8,9 @@ use Symfony\Component\Process\Process;
 
 class PostgreSql extends DbDumper
 {
-    /** @var bool */
-    protected $useInserts = false;
+    protected bool $useInserts = false;
 
-    /** @var bool */
-    protected $createTables = true;
+    protected bool $createTables = true;
 
     /** @var false|resource */
     private $tempFileHandle;
@@ -22,25 +20,14 @@ class PostgreSql extends DbDumper
         $this->port = 5432;
     }
 
-    /**
-     * @return $this
-     */
-    public function useInserts()
+    public function useInserts(): self
     {
         $this->useInserts = true;
 
         return $this;
     }
 
-    /**
-     * Dump the contents of the database to the given file.
-     *
-     * @param string $dumpFile
-     *
-     * @throws \Spatie\DbDumper\Exceptions\CannotStartDump
-     * @throws \Spatie\DbDumper\Exceptions\DumpFailed
-     */
-    public function dumpToFile(string $dumpFile)
+    public function dumpToFile(string $dumpFile): void
     {
         $this->guardAgainstIncompleteCredentials();
 
@@ -54,13 +41,6 @@ class PostgreSql extends DbDumper
         $this->checkIfDumpWasSuccessFul($process, $dumpFile);
     }
 
-    /**
-     * Get the command that should be performed to dump the database.
-     *
-     * @param string $dumpFile
-     *
-     * @return string
-     */
     public function getDumpCommand(string $dumpFile): string
     {
         $quote = $this->determineQuote();
@@ -125,20 +105,13 @@ class PostgreSql extends DbDumper
         ];
     }
 
-    /**
-     * @return $this
-     */
-    public function doNotCreateTables()
+    public function doNotCreateTables(): self
     {
         $this->createTables = false;
 
         return $this;
     }
 
-    /**
-     * @param string $dumpFile
-     * @return Process
-     */
     public function getProcess(string $dumpFile): Process
     {
         $command = $this->getDumpCommand($dumpFile);
@@ -162,7 +135,7 @@ class PostgreSql extends DbDumper
     /**
      * @param false|resource $tempFileHandle
      */
-    public function setTempFileHandle($tempFileHandle)
+    public function setTempFileHandle($tempFileHandle): void
     {
         $this->tempFileHandle = $tempFileHandle;
     }

--- a/src/Databases/Sqlite.php
+++ b/src/Databases/Sqlite.php
@@ -7,14 +7,7 @@ use Symfony\Component\Process\Process;
 
 class Sqlite extends DbDumper
 {
-    /**
-     * Dump the contents of the database to a given file.
-     *
-     * @param string $dumpFile
-     *
-     * @throws \Spatie\DbDumper\Exceptions\DumpFailed
-     */
-    public function dumpToFile(string $dumpFile)
+    public function dumpToFile(string $dumpFile): void
     {
         $process = $this->getProcess($dumpFile);
 
@@ -23,13 +16,6 @@ class Sqlite extends DbDumper
         $this->checkIfDumpWasSuccessFul($process, $dumpFile);
     }
 
-    /**
-     * Get the command that should be performed to dump the database.
-     *
-     * @param string $dumpFile
-     *
-     * @return string
-     */
     public function getDumpCommand(string $dumpFile): string
     {
         $dumpInSqlite = "echo 'BEGIN IMMEDIATE;\n.dump'";
@@ -47,10 +33,6 @@ class Sqlite extends DbDumper
         return $this->echoToFile($command, $dumpFile);
     }
 
-    /**
-     * @param string $dumpFile
-     * @return Process
-     */
     public function getProcess(string $dumpFile): Process
     {
         $command = $this->getDumpCommand($dumpFile);

--- a/src/DbDumper.php
+++ b/src/DbDumper.php
@@ -3,7 +3,6 @@
 namespace Spatie\DbDumper;
 
 use Spatie\DbDumper\Compressors\Compressor;
-use Spatie\DbDumper\Compressors\GzipCompressor;
 use Spatie\DbDumper\Exceptions\CannotSetParameter;
 use Spatie\DbDumper\Exceptions\DumpFailed;
 use Symfony\Component\Process\Process;

--- a/src/DbDumper.php
+++ b/src/DbDumper.php
@@ -110,18 +110,6 @@ abstract class DbDumper
 
         return $this;
     }
-//
-//    /**
-//     * @deprecated
-//     *
-//     * @return $this
-//     */
-//    public function enableCompression()
-//    {
-//        $this->compressor = new GzipCompressor();
-//
-//        return $this;
-//    }
 
     public function getCompressorExtension(): string
     {

--- a/src/DbDumper.php
+++ b/src/DbDumper.php
@@ -110,18 +110,18 @@ abstract class DbDumper
 
         return $this;
     }
-
-    /**
-     * @deprecated
-     *
-     * @return $this
-     */
-    public function enableCompression()
-    {
-        $this->compressor = new GzipCompressor();
-
-        return $this;
-    }
+//
+//    /**
+//     * @deprecated
+//     *
+//     * @return $this
+//     */
+//    public function enableCompression()
+//    {
+//        $this->compressor = new GzipCompressor();
+//
+//        return $this;
+//    }
 
     public function getCompressorExtension(): string
     {

--- a/src/DbDumper.php
+++ b/src/DbDumper.php
@@ -10,46 +10,33 @@ use Symfony\Component\Process\Process;
 
 abstract class DbDumper
 {
-    /** @var string */
-    protected $dbName;
+    protected string $dbName = '';
 
-    /** @var string */
-    protected $userName;
+    protected string $userName = '';
 
-    /** @var string */
-    protected $password;
+    protected string $password = '';
 
-    /** @var string */
-    protected $host = 'localhost';
+    protected string $host = 'localhost';
 
-    /** @var int */
-    protected $port = 5432;
+    protected int $port = 5432;
 
-    /** @var string */
-    protected $socket = '';
+    protected string $socket = '';
 
-    /** @var int */
-    protected $timeout = 0;
+    protected int $timeout = 0;
 
-    /** @var string */
-    protected $dumpBinaryPath = '';
+    protected string $dumpBinaryPath = '';
 
-    /** @var array */
-    protected $includeTables = [];
+    protected array $includeTables = [];
 
-    /** @var array */
-    protected $excludeTables = [];
+    protected array $excludeTables = [];
 
-    /** @var array */
-    protected $extraOptions = [];
+    protected array $extraOptions = [];
 
-    /** @var array */
-    protected $extraOptionsAfterDbName = [];
+    protected array $extraOptionsAfterDbName = [];
 
-    /** @var object */
-    protected $compressor = null;
+    protected ?object $compressor = null;
 
-    public static function create()
+    public static function create(): static
     {
         return new static();
     }
@@ -59,48 +46,28 @@ abstract class DbDumper
         return $this->dbName;
     }
 
-    /**
-     * @param string $dbName
-     *
-     * @return $this
-     */
-    public function setDbName(string $dbName)
+    public function setDbName(string $dbName): self
     {
         $this->dbName = $dbName;
 
         return $this;
     }
 
-    /**
-     * @param string $userName
-     *
-     * @return $this
-     */
-    public function setUserName(string $userName)
+    public function setUserName(string $userName): self
     {
         $this->userName = $userName;
 
         return $this;
     }
 
-    /**
-     * @param string $password
-     *
-     * @return $this
-     */
-    public function setPassword(string $password)
+    public function setPassword(string $password): self
     {
         $this->password = $password;
 
         return $this;
     }
 
-    /**
-     * @param string $host
-     *
-     * @return $this
-     */
-    public function setHost(string $host)
+    public function setHost(string $host): self
     {
         $this->host = $host;
 
@@ -112,45 +79,30 @@ abstract class DbDumper
         return $this->host;
     }
 
-    /**
-     * @param int $port
-     *
-     * @return $this
-     */
-    public function setPort(int $port)
+    public function setPort(int $port): self
     {
         $this->port = $port;
 
         return $this;
     }
 
-    /**
-     * @param string $socket
-     *
-     * @return $this
-     */
-    public function setSocket(string $socket)
+    public function setSocket(string $socket): self
     {
         $this->socket = $socket;
 
         return $this;
     }
 
-    /**
-     * @param int $timeout
-     *
-     * @return $this
-     */
-    public function setTimeout(int $timeout)
+    public function setTimeout(int $timeout): self
     {
         $this->timeout = $timeout;
 
         return $this;
     }
 
-    public function setDumpBinaryPath(string $dumpBinaryPath)
+    public function setDumpBinaryPath(string $dumpBinaryPath): self
     {
-        if ($dumpBinaryPath !== '' && substr($dumpBinaryPath, -1) !== '/') {
+        if ($dumpBinaryPath !== '' && ! str_ends_with($dumpBinaryPath, '/')) {
             $dumpBinaryPath .= '/';
         }
 
@@ -176,21 +128,14 @@ abstract class DbDumper
         return $this->compressor->useExtension();
     }
 
-    public function useCompressor(Compressor $compressor)
+    public function useCompressor(Compressor $compressor): self
     {
         $this->compressor = $compressor;
 
         return $this;
     }
 
-    /**
-     * @param string|array $includeTables
-     *
-     * @return $this
-     *
-     * @throws \Spatie\DbDumper\Exceptions\CannotSetParameter
-     */
-    public function includeTables($includeTables)
+    public function includeTables(string | array $includeTables): self
     {
         if (! empty($this->excludeTables)) {
             throw CannotSetParameter::conflictingParameters('includeTables', 'excludeTables');
@@ -205,14 +150,7 @@ abstract class DbDumper
         return $this;
     }
 
-    /**
-     * @param string|array $excludeTables
-     *
-     * @return $this
-     *
-     * @throws \Spatie\DbDumper\Exceptions\CannotSetParameter
-     */
-    public function excludeTables($excludeTables)
+    public function excludeTables(string | array $excludeTables): self
     {
         if (! empty($this->includeTables)) {
             throw CannotSetParameter::conflictingParameters('excludeTables', 'includeTables');
@@ -227,12 +165,7 @@ abstract class DbDumper
         return $this;
     }
 
-    /**
-     * @param string $extraOption
-     *
-     * @return $this
-     */
-    public function addExtraOption(string $extraOption)
+    public function addExtraOption(string $extraOption): self
     {
         if (! empty($extraOption)) {
             $this->extraOptions[] = $extraOption;
@@ -241,12 +174,7 @@ abstract class DbDumper
         return $this;
     }
 
-    /**
-     * @param string $extraOptionAtEnd
-     *
-     * @return $this
-     */
-    public function addExtraOptionAfterDbName(string $extraOptionAfterDbName)
+    public function addExtraOptionAfterDbName(string $extraOptionAfterDbName): self
     {
         if (! empty($extraOptionAfterDbName)) {
             $this->extraOptionsAfterDbName[] = $extraOptionAfterDbName;
@@ -255,9 +183,9 @@ abstract class DbDumper
         return $this;
     }
 
-    abstract public function dumpToFile(string $dumpFile);
+    abstract public function dumpToFile(string $dumpFile): void;
 
-    public function checkIfDumpWasSuccessFul(Process $process, string $outputFile)
+    public function checkIfDumpWasSuccessFul(Process $process, string $outputFile): void
     {
         if (! $process->isSuccessful()) {
             throw DumpFailed::processDidNotEndSuccessfully($process);
@@ -301,6 +229,6 @@ abstract class DbDumper
 
     protected function isWindows(): bool
     {
-        return strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
+        return str_starts_with(strtoupper(PHP_OS), 'WIN');
     }
 }

--- a/src/Exceptions/CannotSetParameter.php
+++ b/src/Exceptions/CannotSetParameter.php
@@ -6,13 +6,7 @@ use Exception;
 
 class CannotSetParameter extends Exception
 {
-    /**
-     * @param string $name
-     * @param string $conflictName
-     *
-     * @return \Spatie\DbDumper\Exceptions\CannotSetParameter
-     */
-    public static function conflictingParameters($name, $conflictName)
+    public static function conflictingParameters(string $name, string $conflictName): static
     {
         return new static("Cannot set `{$name}` because it conflicts with parameter `{$conflictName}`.");
     }

--- a/src/Exceptions/CannotStartDump.php
+++ b/src/Exceptions/CannotStartDump.php
@@ -6,12 +6,7 @@ use Exception;
 
 class CannotStartDump extends Exception
 {
-    /**
-     * @param string $name
-     *
-     * @return \Spatie\DbDumper\Exceptions\CannotStartDump
-     */
-    public static function emptyParameter($name)
+    public static function emptyParameter(string $name): static
     {
         return new static("Parameter `{$name}` cannot be empty.");
     }

--- a/src/Exceptions/DumpFailed.php
+++ b/src/Exceptions/DumpFailed.php
@@ -7,28 +7,17 @@ use Symfony\Component\Process\Process;
 
 class DumpFailed extends Exception
 {
-    /**
-     * @param \Symfony\Component\Process\Process $process
-     *
-     * @return \Spatie\DbDumper\Exceptions\DumpFailed
-     */
-    public static function processDidNotEndSuccessfully(Process $process)
+    public static function processDidNotEndSuccessfully(Process $process): static
     {
         return new static("The dump process failed with exitcode {$process->getExitCode()} : {$process->getExitCodeText()} : {$process->getErrorOutput()}");
     }
 
-    /**
-     * @return \Spatie\DbDumper\Exceptions\DumpFailed
-     */
-    public static function dumpfileWasNotCreated()
+    public static function dumpfileWasNotCreated(): static
     {
         return new static('The dumpfile could not be created');
     }
 
-    /**
-     * @return \Spatie\DbDumper\Exceptions\DumpFailed
-     */
-    public static function dumpfileWasEmpty()
+    public static function dumpfileWasEmpty(): static
     {
         return new static('The created dumpfile is empty');
     }

--- a/tests/MongoDbTest.php
+++ b/tests/MongoDbTest.php
@@ -35,19 +35,6 @@ class MongoDbTest extends TestCase
     }
 
     /** @test */
-    public function it_can_generate_a_dump_command_with_compression_enabled()
-    {
-        $dumpCommand = MongoDb::create()
-            ->setDbName('dbname')
-            ->enableCompression()
-            ->getDumpCommand('dbname.gz');
-
-        $expected = '((((\'mongodump\' --db dbname --archive --host localhost --port 27017; echo $? >&3) | gzip > "dbname.gz") 3>&1) | (read x; exit $x))';
-
-        $this->assertSame($expected, $dumpCommand);
-    }
-
-    /** @test */
     public function it_can_generate_a_dump_command_with_gzip_compressor_enabled()
     {
         $dumpCommand = MongoDb::create()

--- a/tests/MongoDbTest.php
+++ b/tests/MongoDbTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\DbDumper\Test;
 
 use PHPUnit\Framework\TestCase;
+use Spatie\DbDumper\Compressors\Bzip2Compressor;
 use Spatie\DbDumper\Compressors\GzipCompressor;
 use Spatie\DbDumper\Databases\MongoDb;
 use Spatie\DbDumper\Exceptions\CannotStartDump;
@@ -43,6 +44,19 @@ class MongoDbTest extends TestCase
             ->getDumpCommand('dbname.gz');
 
         $expected = '((((\'mongodump\' --db dbname --archive --host localhost --port 27017; echo $? >&3) | gzip > "dbname.gz") 3>&1) | (read x; exit $x))';
+
+        $this->assertSame($expected, $dumpCommand);
+    }
+
+    /** @test */
+    public function it_can_generate_a_dump_command_with_bzip2_compressor_enabled()
+    {
+        $dumpCommand = MongoDb::create()
+            ->setDbName('dbname')
+            ->useCompressor(new Bzip2Compressor)
+            ->getDumpCommand('dbname.bz2');
+
+        $expected = '((((\'mongodump\' --db dbname --archive --host localhost --port 27017; echo $? >&3) | bzip2 > "dbname.bz2") 3>&1) | (read x; exit $x))';
 
         $this->assertSame($expected, $dumpCommand);
     }

--- a/tests/MySqlTest.php
+++ b/tests/MySqlTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\DbDumper\Test;
 
 use PHPUnit\Framework\TestCase;
+use Spatie\DbDumper\Compressors\Bzip2Compressor;
 use Spatie\DbDumper\Compressors\GzipCompressor;
 use Spatie\DbDumper\Databases\MySql;
 use Spatie\DbDumper\Exceptions\CannotSetParameter;
@@ -62,6 +63,21 @@ class MySqlTest extends TestCase
             ->getDumpCommand('dump.sql', 'credentials.txt');
 
         $expected = '((((\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname; echo $? >&3) | gzip > "dump.sql") 3>&1) | (read x; exit $x))';
+
+        $this->assertSame($expected, $dumpCommand);
+    }
+
+    /** @test */
+    public function it_can_generate_a_dump_command_with_bzip2_compressor_enabled()
+    {
+        $dumpCommand = MySql::create()
+            ->setDbName('dbname')
+            ->setUserName('username')
+            ->setPassword('password')
+            ->useCompressor(new Bzip2Compressor)
+            ->getDumpCommand('dump.sql', 'credentials.txt');
+
+        $expected = '((((\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname; echo $? >&3) | bzip2 > "dump.sql") 3>&1) | (read x; exit $x))';
 
         $this->assertSame($expected, $dumpCommand);
     }

--- a/tests/MySqlTest.php
+++ b/tests/MySqlTest.php
@@ -37,21 +37,6 @@ class MySqlTest extends TestCase
     }
 
     /** @test */
-    public function it_can_generate_a_dump_command_with_compression_enabled()
-    {
-        $dumpCommand = MySql::create()
-            ->setDbName('dbname')
-            ->setUserName('username')
-            ->setPassword('password')
-            ->enableCompression()
-            ->getDumpCommand('dump.sql', 'credentials.txt');
-
-        $expected = '((((\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname; echo $? >&3) | gzip > "dump.sql") 3>&1) | (read x; exit $x))';
-
-        $this->assertSame($expected, $dumpCommand);
-    }
-
-    /** @test */
     public function it_can_generate_a_dump_command_with_columnstatistics()
     {
         $dumpCommand = MySql::create()
@@ -193,7 +178,7 @@ class MySqlTest extends TestCase
             ->setPassword('password')
             ->setSocket(1234)
             ->getDumpCommand('dump.sql', 'credentials.txt');
-        
+
         $this->assertSame('\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert --socket=1234 dbname > "dump.sql"', $dumpCommand);
     }
 

--- a/tests/PostgreSqlTest.php
+++ b/tests/PostgreSqlTest.php
@@ -37,21 +37,6 @@ class PostgreSqlTest extends TestCase
     }
 
     /** @test */
-    public function it_can_generate_a_dump_command_with_compression_enabled()
-    {
-        $dumpCommand = PostgreSql::create()
-            ->setDbName('dbname')
-            ->setUserName('username')
-            ->setPassword('password')
-            ->enableCompression()
-            ->getDumpCommand('dump.sql');
-
-        $expected = '((((\'pg_dump\' -U username -h localhost -p 5432; echo $? >&3) | gzip > "dump.sql") 3>&1) | (read x; exit $x))';
-
-        $this->assertSame($expected, $dumpCommand);
-    }
-
-    /** @test */
     public function it_can_generate_a_dump_command_with_gzip_compressor_enabled()
     {
         $dumpCommand = PostgreSql::create()

--- a/tests/PostgreSqlTest.php
+++ b/tests/PostgreSqlTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\DbDumper\Test;
 
 use PHPUnit\Framework\TestCase;
+use Spatie\DbDumper\Compressors\Bzip2Compressor;
 use Spatie\DbDumper\Compressors\GzipCompressor;
 use Spatie\DbDumper\Databases\PostgreSql;
 use Spatie\DbDumper\Exceptions\CannotSetParameter;
@@ -47,6 +48,21 @@ class PostgreSqlTest extends TestCase
             ->getDumpCommand('dump.sql');
 
         $expected = '((((\'pg_dump\' -U username -h localhost -p 5432; echo $? >&3) | gzip > "dump.sql") 3>&1) | (read x; exit $x))';
+
+        $this->assertSame($expected, $dumpCommand);
+    }
+
+    /** @test */
+    public function it_can_generate_a_dump_command_with_bzip2_compressor_enabled()
+    {
+        $dumpCommand = PostgreSql::create()
+            ->setDbName('dbname')
+            ->setUserName('username')
+            ->setPassword('password')
+            ->useCompressor(new Bzip2Compressor)
+            ->getDumpCommand('dump.sql');
+
+        $expected = '((((\'pg_dump\' -U username -h localhost -p 5432; echo $? >&3) | bzip2 > "dump.sql") 3>&1) | (read x; exit $x))';
 
         $this->assertSame($expected, $dumpCommand);
     }

--- a/tests/SqliteTest.php
+++ b/tests/SqliteTest.php
@@ -27,20 +27,6 @@ class SqliteTest extends TestCase
     }
 
     /** @test */
-    public function it_can_generate_a_dump_command_with_compression_enabled()
-    {
-        $dumpCommand = Sqlite::create()
-            ->setDbName('dbname.sqlite')
-            ->enableCompression()
-            ->getDumpCommand('dump.sql');
-
-        $expected = '((((echo \'BEGIN IMMEDIATE;
-.dump\' | \'sqlite3\' --bail \'dbname.sqlite\'; echo $? >&3) | gzip > "dump.sql") 3>&1) | (read x; exit $x))';
-
-        $this->assertEquals($expected, $dumpCommand);
-    }
-
-    /** @test */
     public function it_can_generate_a_dump_command_with_gzip_compressor_enabled()
     {
         $dumpCommand = Sqlite::create()

--- a/tests/SqliteTest.php
+++ b/tests/SqliteTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\DbDumper\Test;
 
 use PHPUnit\Framework\TestCase;
+use Spatie\DbDumper\Compressors\Bzip2Compressor;
 use Spatie\DbDumper\Compressors\GzipCompressor;
 use Spatie\DbDumper\Databases\Sqlite;
 
@@ -36,6 +37,20 @@ class SqliteTest extends TestCase
 
         $expected = '((((echo \'BEGIN IMMEDIATE;
 .dump\' | \'sqlite3\' --bail \'dbname.sqlite\'; echo $? >&3) | gzip > "dump.sql") 3>&1) | (read x; exit $x))';
+
+        $this->assertEquals($expected, $dumpCommand);
+    }
+
+    /** @test */
+    public function it_can_generate_a_dump_command_with_bzip2_compressor_enabled()
+    {
+        $dumpCommand = Sqlite::create()
+            ->setDbName('dbname.sqlite')
+            ->useCompressor(new Bzip2Compressor)
+            ->getDumpCommand('dump.sql');
+
+        $expected = '((((echo \'BEGIN IMMEDIATE;
+.dump\' | \'sqlite3\' --bail \'dbname.sqlite\'; echo $? >&3) | bzip2 > "dump.sql") 3>&1) | (read x; exit $x))';
 
         $this->assertEquals($expected, $dumpCommand);
     }


### PR DESCRIPTION
This PR adds a new major version, v3.0.0.

Specifically, it:

- Removes support for all PHP 7.x versions.
- Requires PHP 8.0+.
- Uses PHP 8 syntax where possible.
- Removes unnecessary PHP docblocks per Spatie's guidelines.
- Removes unneeded Laravel configuration in the tests workflow.
- Removes the deprecated method `enableCompression()` from the `DbDumper` class _(and related tests)_.
- Adds a `Bzip2Compressor` compressor and associated unit tests _(uses `bzip2` to create `.bz2` files)_.
- Adds/updates several files to more closely match `spatie/package-skeleton-php`.
- Updates the readme to reflect the new compressor class, and adds `gzip` and `bzip2` to the "requirements" section.
- Bumps the minimum `PHPUnit` version to `9.5`.
- Bumps the minimum version of `symfony/process` to `5.0`.
- _Updates the changelog - release date needs to be updated, currently is "unreleased"._