### PR TITLE
Escape special characters in PostgreSQL credential entries

### DIFF
--- a/src/Databases/PostgreSql.php
+++ b/src/Databases/PostgreSql.php
@@ -88,10 +88,11 @@ class PostgreSql extends DbDumper
         return implode(':', $contents);
     }
 
-    private function escapeCredentialEntry($entry)
+    protected function escapeCredentialEntry($entry): string
     {
         $entry = str_replace('\\', '\\\\', $entry);
         $entry = str_replace(':', '\\:', $entry);
+        
         return $entry;
     }
 

--- a/src/Databases/PostgreSql.php
+++ b/src/Databases/PostgreSql.php
@@ -74,18 +74,25 @@ class PostgreSql extends DbDumper
 
         return $this->echoToFile(implode(' ', $command), $dumpFile);
     }
-
+    
     public function getContentsOfCredentialsFile(): string
     {
         $contents = [
-            $this->host,
-            $this->port,
-            $this->dbName,
-            $this->userName,
-            $this->password,
+            $this->escapeCredentialEntry($this->host),
+            $this->escapeCredentialEntry($this->port),
+            $this->escapeCredentialEntry($this->dbName),
+            $this->escapeCredentialEntry($this->userName),
+            $this->escapeCredentialEntry($this->password),
         ];
 
         return implode(':', $contents);
+    }
+
+    private function escapeCredentialEntry($entry)
+    {
+        $entry = str_replace('\\', '\\\\', $entry);
+        $entry = str_replace(':', '\\:', $entry);
+        return $entry;
     }
 
     public function guardAgainstIncompleteCredentials()


### PR DESCRIPTION
PostgreSQL connection fails if the password (or any other credential?) contains `\` or `:`. This PR escapes the characters in the credentials prior to initiating connection.

As per: https://www.postgresql.org/docs/14/libpq-pgpass.html

It gets a little crazy as we need to escape the escape characters in the PHP code.