### PR TITLE
Fix: Replaced single quotes in mongodb dump command in windows env

### DIFF
--- a/src/Databases/MongoDb.php
+++ b/src/Databases/MongoDb.php
@@ -66,11 +66,11 @@ class MongoDb extends DbDumper
         ];
 
         if ($this->userName) {
-            $command[] = "--username '{$this->userName}'";
+            $command[] = "--username {$quote}{$this->userName}{$quote}";
         }
 
         if ($this->password) {
-            $command[] = "--password '{$this->password}'";
+            $command[] = "--password {$quote}{$this->password}{$quote}";
         }
 
         if (isset($this->host)) {


### PR DESCRIPTION
Hello,
I'm facing a problem trying to dump mongodb in my environment.

Env:
laravel/framework: 8.83
mongodb: 5.0.1
so: win11

´
The dump process failed with a none successful exitcode. Exitcode ======== 1: General error Output ====== <no output> Error Output ============ 2022-06-14T11:54:00.381-0300 Failed: can't create session: could not connect to server: connection() error occured during connection handshake: auth error: sasl conversation error: unable to authenticate using mechanism "SCRAM-SHA-1": (AuthenticationFailed) Authentication failed.
´

After some tests I found that the problem was in the use of single quotes in the command, in file \Spatie\DbDumper\Databases\MongoDb.php.I replace the single quotes from the username and password the code ran successfully. (lines 69 and 73 of \Spatie\DbDumper\Databases\MongoDb.php );

Dumping is successfully done with double quotes in windows env.