### PR TITLE
[MySQL] Use --defaults-file for config file

### DIFF
--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -171,7 +171,7 @@ class MySql extends DbDumper
 
         $command = [
             "{$quote}{$this->dumpBinaryPath}mysqldump{$quote}",
-            "--defaults-extra-file=\"{$temporaryCredentialsFile}\"",
+            "--defaults-file=\"{$temporaryCredentialsFile}\"",
         ];
 
         if (! $this->createTables) {


### PR DESCRIPTION
Per title, this change sets the MySQL dumper to use `--defaults-file` instead of `--defaults-extra-file`.

This fixes an issue I am experiencing when using the `laravel-backup` package. The root issue is that my App uses a fully remote database with values configured in Laravel. However the Dumping command will load and use the `~/.my.cnf` file configured for my local MySQL. This results in the temporary client config file not being used correctly for some reason - instead it connects to my local device via the LAN ip.

> mysqldump: Got error: 1045: "Access denied for user 'root'@'192.168.1.204' (using password: YES)" when trying to connect