### PR TITLE
Add support for database URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,9 @@
 [![MIT Licensed](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
 [![Total Downloads](https://img.shields.io/packagist/dt/spatie/db-dumper.svg?style=flat-square)](https://packagist.org/packages/spatie/db-dumper)
 
-This repo contains an easy to use class to dump a database using PHP. Currently MySQL, PostgreSQL, SQLite and MongoDB are supported. Behind
-the scenes `mysqldump`, `pg_dump`, `sqlite3` and `mongodump` are used.
+This repo contains an easy to use class to dump a database using PHP. Currently MySQL, PostgreSQL, SQLite and MongoDB are supported. Behind the scenes `mysqldump`, `pg_dump`, `sqlite3` and `mongodump` are used.
 
-Here's are simple examples of how to create a database dump with different drivers:
+Here are simple examples of how to create a database dump with different drivers:
 
 **MySQL**
 
@@ -123,6 +122,20 @@ Spatie\DbDumper\Databases\MySql::create()
     ->setHost($host)
     ->dumpToFile('dump.sql');
 ```
+
+### Use a Database URL
+
+In some applications or environments, database credentials are provided as URLs instead of individual components. In this case, you can use the `setDatabaseUrl` method instead of the individual methods.
+
+```php
+Spatie\DbDumper\Databases\MySql::create()
+    ->setDatabaseUrl($databaseUrl)
+    ->dumpToFile('dump.sql');
+```
+
+When providing a URL, the package will automatically parse it and provide the individual components to the applicable dumper.
+
+For example, if you provide the URL `mysql://username:password@hostname:3306/dbname`, the dumper will use the `hostname` host, running on port `3306`, and will connect to `dbname` with `username` and `password`.
 
 ### Dump specific tables
 

--- a/src/DsnParser.php
+++ b/src/DsnParser.php
@@ -79,7 +79,7 @@ class DsnParser
         $parsedUrl = parse_url($url);
 
         if ($parsedUrl === false) {
-            throw new InvalidDatabaseUrl($url);
+            throw InvalidDatabaseUrl::invalidUrl($url);
         }
 
         return $parsedUrl;

--- a/src/DsnParser.php
+++ b/src/DsnParser.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Spatie\DbDumper;
+
+use Spatie\DbDumper\Exceptions\InvalidDatabaseUrl;
+
+class DsnParser
+{
+    protected string $dsn;
+
+    public function __construct(string $dsn)
+    {
+        $this->dsn = $dsn;
+    }
+
+    public function parse(): array
+    {
+        $rawComponents = $this->parseUrl($this->dsn);
+
+        $decodedComponents = $this->parseNativeTypes(
+            array_map('rawurldecode', $rawComponents)
+        );
+
+        return array_merge(
+            $this->getPrimaryOptions($decodedComponents),
+            $this->getQueryOptions($rawComponents)
+        );
+    }
+
+    protected function getPrimaryOptions($url): array
+    {
+        return array_filter([
+            'database' => $this->getDatabase($url),
+            'host' => $url['host'] ?? null,
+            'port' => $url['port'] ?? null,
+            'username' => $url['user'] ?? null,
+            'password' => $url['pass'] ?? null,
+        ], static fn ($value) => ! is_null($value));
+    }
+
+    protected function getDatabase($url): ?string
+    {
+        $path = $url['path'] ?? null;
+
+        if (! $path) {
+            return null;
+        }
+
+        if ($path === '/') {
+            return null;
+        }
+
+        if (isset($url['scheme']) && str_contains($url['scheme'], 'sqlite')) {
+            return $path;
+        }
+
+        return trim($path, '/');
+    }
+
+    protected function getQueryOptions($url)
+    {
+        $queryString = $url['query'] ?? null;
+
+        if (! $queryString) {
+            return [];
+        }
+
+        $query = [];
+
+        parse_str($queryString, $query);
+
+        return $this->parseNativeTypes($query);
+    }
+
+    protected function parseUrl($url): array
+    {
+        $url = preg_replace('#^(sqlite3?):///#', '$1://null/', $url);
+
+        $parsedUrl = parse_url($url);
+
+        if ($parsedUrl === false) {
+            throw new InvalidDatabaseUrl($url);
+        }
+
+        return $parsedUrl;
+    }
+
+    protected function parseNativeTypes($value)
+    {
+        if (is_array($value)) {
+            return array_map([$this, 'parseNativeTypes'], $value);
+        }
+
+        if (! is_string($value)) {
+            return $value;
+        }
+
+        $parsedValue = json_decode($value, true);
+
+        if (json_last_error() === JSON_ERROR_NONE) {
+            return $parsedValue;
+        }
+
+        return $value;
+    }
+}

--- a/src/Exceptions/InvalidDatabaseUrl.php
+++ b/src/Exceptions/InvalidDatabaseUrl.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\DbDumper\Exceptions;
+
+use Exception;
+
+class InvalidDatabaseUrl extends Exception
+{
+    public static function invalidUrl(string $databaseUrl): static
+    {
+        return new static("Database URL `{$databaseUrl}` is invalid and cannot be parsed.");
+    }
+}

--- a/tests/MongoDbTest.php
+++ b/tests/MongoDbTest.php
@@ -22,6 +22,17 @@ it('can generate a dump command', function () {
         . ' --archive --host localhost --port 27017 > "dbname.gz"');
 });
 
+it('can generate a dump command using a database url', function () {
+    $dumpCommand = MongoDb::create()
+        ->setDatabaseUrl('monogodb://username:password@localhost:27017/dbname')
+        ->getDumpCommand('dbname.gz');
+
+    expect($dumpCommand)->toEqual(
+        '\'mongodump\' --db dbname'
+            . ' --archive --username \'username\' --password \'password\' --host localhost --port 27017 > "dbname.gz"'
+    );
+});
+
 it('can generate a dump command with gzip compressor enabled', function () {
     $dumpCommand = MongoDb::create()
         ->setDbName('dbname')

--- a/tests/MySqlTest.php
+++ b/tests/MySqlTest.php
@@ -26,6 +26,16 @@ it('can generate a dump command', function () {
     );
 });
 
+it('can generate a dump command using a database url', function () {
+    $dumpCommand = Mysql::create()
+        ->setDatabaseUrl('mysql://username:password@hostname:3306/dbname')
+        ->getDumpCommand('dump.sql', 'credentials.txt');
+
+    expect($dumpCommand)->toEqual(
+        '\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname > "dump.sql"'
+    );
+});
+
 it('can generate a dump command with columnstatistics', function () {
     $dumpCommand = MySql::create()
         ->setDbName('dbname')

--- a/tests/PostgreSqlTest.php
+++ b/tests/PostgreSqlTest.php
@@ -21,7 +21,15 @@ it('can generate a dump command', function () {
         ->setPassword('password')
         ->getDumpCommand('dump.sql');
 
-    expect($dumpCommand)->toEqual('\'pg_dump\' -U username -h localhost -p 5432 > "dump.sql"');
+    expect($dumpCommand)->toEqual('\'pg_dump\' -U "username" -h localhost -p 5432 > "dump.sql"');
+});
+
+it('can generate a dump command using a database url', function () {
+    $dumpCommand = Postgresql::create()
+        ->setDatabaseUrl('postgres://username:password@hostname:5432/dbname')
+        ->getDumpCommand('dump.sql');
+
+    expect($dumpCommand)->toEqual('\'pg_dump\' -U "username" -h hostname -p 5432 > "dump.sql"');
 });
 
 it('can generate a dump command with gzip compressor enabled', function () {
@@ -33,7 +41,7 @@ it('can generate a dump command with gzip compressor enabled', function () {
         ->getDumpCommand('dump.sql');
 
     expect($dumpCommand)->toEqual(
-        '((((\'pg_dump\' -U username -h localhost -p 5432; echo $? >&3) | gzip > "dump.sql") 3>&1) | (read x; exit $x))'
+        '((((\'pg_dump\' -U "username" -h localhost -p 5432; echo $? >&3) | gzip > "dump.sql") 3>&1) | (read x; exit $x))'
     );
 });
 
@@ -45,7 +53,7 @@ it('can generate a dump command with bzip2 compressor enabled', function () {
         ->useCompressor(new Bzip2Compressor())
         ->getDumpCommand('dump.sql');
 
-    $expected = '((((\'pg_dump\' -U username -h localhost -p 5432; echo $? >&3) | bzip2 > "dump.sql") 3>&1) | (read x; exit $x))';
+    $expected = '((((\'pg_dump\' -U "username" -h localhost -p 5432; echo $? >&3) | bzip2 > "dump.sql") 3>&1) | (read x; exit $x))';
 
     expect($dumpCommand)->toEqual($expected);
 });
@@ -58,7 +66,7 @@ it('can generate a dump command with absolute path having space and brackets', f
         ->getDumpCommand('/save/to/new (directory)/dump.sql');
 
     expect($dumpCommand)->toEqual(
-        '\'pg_dump\' -U username -h localhost -p 5432 > "/save/to/new (directory)/dump.sql"'
+        '\'pg_dump\' -U "username" -h localhost -p 5432 > "/save/to/new (directory)/dump.sql"'
     );
 });
 
@@ -71,7 +79,7 @@ it('can generate a dump command with using inserts', function () {
         ->getDumpCommand('dump.sql');
 
     expect($dumpCommand)->toEqual(
-        '\'pg_dump\' -U username -h localhost -p 5432 --inserts > "dump.sql"'
+        '\'pg_dump\' -U "username" -h localhost -p 5432 --inserts > "dump.sql"'
     );
 });
 
@@ -83,7 +91,7 @@ it('can generate a dump command with a custom port', function () {
         ->setPort(1234)
         ->getDumpCommand('dump.sql');
 
-    expect($dumpCommand)->toEqual('\'pg_dump\' -U username -h localhost -p 1234 > "dump.sql"');
+    expect($dumpCommand)->toEqual('\'pg_dump\' -U "username" -h localhost -p 1234 > "dump.sql"');
 });
 
 it('can generate a dump command with custom binary path', function () {
@@ -94,7 +102,7 @@ it('can generate a dump command with custom binary path', function () {
         ->setDumpBinaryPath('/custom/directory')
         ->getDumpCommand('dump.sql');
 
-    expect($dumpCommand)->toEqual('\'/custom/directory/pg_dump\' -U username -h localhost -p 5432 > "dump.sql"');
+    expect($dumpCommand)->toEqual('\'/custom/directory/pg_dump\' -U "username" -h localhost -p 5432 > "dump.sql"');
 });
 
 it('can generate a dump command with a custom socket', function () {
@@ -105,7 +113,7 @@ it('can generate a dump command with a custom socket', function () {
         ->setSocket('/var/socket.1234')
         ->getDumpCommand('dump.sql');
 
-    expect($dumpCommand)->toEqual('\'pg_dump\' -U username -h /var/socket.1234 -p 5432 > "dump.sql"');
+    expect($dumpCommand)->toEqual('\'pg_dump\' -U "username" -h /var/socket.1234 -p 5432 > "dump.sql"');
 });
 
 it('can generate a dump command for specific tables as array', function () {
@@ -116,7 +124,7 @@ it('can generate a dump command for specific tables as array', function () {
         ->includeTables(['tb1', 'tb2', 'tb3'])
         ->getDumpCommand('dump.sql', 'credentials.txt');
 
-    expect($dumpCommand)->toEqual('\'pg_dump\' -U username -h localhost -p 5432 -t tb1 -t tb2 -t tb3 > "dump.sql"');
+    expect($dumpCommand)->toEqual('\'pg_dump\' -U "username" -h localhost -p 5432 -t tb1 -t tb2 -t tb3 > "dump.sql"');
 });
 
 it('can generate a dump command for specific tables as string', function () {
@@ -127,7 +135,7 @@ it('can generate a dump command for specific tables as string', function () {
         ->includeTables('tb1, tb2, tb3')
         ->getDumpCommand('dump.sql', 'credentials.txt');
 
-    expect($dumpCommand)->toEqual('\'pg_dump\' -U username -h localhost -p 5432 -t tb1 -t tb2 -t tb3 > "dump.sql"');
+    expect($dumpCommand)->toEqual('\'pg_dump\' -U "username" -h localhost -p 5432 -t tb1 -t tb2 -t tb3 > "dump.sql"');
 });
 
 it('will throw an exception when setting exclude tables after setting tables', function () {
@@ -148,7 +156,7 @@ it('can generate a dump command excluding tables as array', function () {
         ->getDumpCommand('dump.sql', 'credentials.txt');
 
     expect($dumpCommand)->toEqual(
-        '\'pg_dump\' -U username -h localhost -p 5432 -T tb1 -T tb2 -T tb3 > "dump.sql"'
+        '\'pg_dump\' -U "username" -h localhost -p 5432 -T tb1 -T tb2 -T tb3 > "dump.sql"'
     );
 });
 
@@ -161,7 +169,7 @@ it('can generate a dump command excluding tables as string', function () {
         ->getDumpCommand('dump.sql', 'credentials.txt');
 
     expect($dumpCommand)->toEqual(
-        '\'pg_dump\' -U username -h localhost -p 5432 -T tb1 -T tb2 -T tb3 > "dump.sql"'
+        '\'pg_dump\' -U "username" -h localhost -p 5432 -T tb1 -T tb2 -T tb3 > "dump.sql"'
     );
 });
 
@@ -203,7 +211,7 @@ it('can add an extra option', function () {
         ->getDumpCommand('dump.sql');
 
     expect($dumpCommand)->toEqual(
-        '\'pg_dump\' -U username -h localhost -p 5432 -something-else > "dump.sql"'
+        '\'pg_dump\' -U "username" -h localhost -p 5432 -something-else > "dump.sql"'
     );
 });
 
@@ -219,7 +227,7 @@ it('can generate a dump command with no create info', function () {
         ->setUserName('username')
         ->setPassword('password')
         ->doNotCreateTables()
-        ->getDumpCommand('dump.sql', 'credentials.txt');
+        ->getDumpCommand('dump.sql');
 
-    expect($dumpCommand)->toEqual('\'pg_dump\' -U username -h localhost -p 5432 --data-only > "dump.sql"');
+    expect($dumpCommand)->toEqual('\'pg_dump\' -U "username" -h localhost -p 5432 --data-only > "dump.sql"');
 });

--- a/tests/SqliteTest.php
+++ b/tests/SqliteTest.php
@@ -22,6 +22,26 @@ it('can generate a dump command', function () {
     expect($dumpCommand)->toEqual($expected);
 });
 
+it('can generate a dump command using a database url containing an absolute path', function () {
+    $dumpCommand = Sqlite::create()
+        ->setDatabaseUrl('sqlite:///path/to/dbname.sqlite')
+        ->getDumpCommand('dump.sql');
+
+    expect($dumpCommand)->toEqual(
+        "echo 'BEGIN IMMEDIATE;\n.dump' | 'sqlite3' --bail '/path/to/dbname.sqlite' > \"dump.sql\""
+    );
+});
+
+it('can generate a dump command using a database url containing a relative path', function () {
+    $dumpCommand = Sqlite::create()
+        ->setDatabaseUrl('sqlite:dbname.sqlite')
+        ->getDumpCommand('dump.sql');
+
+    expect($dumpCommand)->toEqual(
+        "echo 'BEGIN IMMEDIATE;\n.dump' | 'sqlite3' --bail 'dbname.sqlite' > \"dump.sql\""
+    );
+});
+
 it('can generate a dump command with gzip compressor enabled', function () {
     $dumpCommand = Sqlite::create()
         ->setDbName('dbname.sqlite')


### PR DESCRIPTION
Adds basic support for database URLs, or DSNs. It does so via the addition of a DSN parser that is derived from the one Laravel provides (it's a simplified version that only works with strings).

Resolves #195.

> **Note:** Tests were failing due to the recent addition of quoted usernames in `PostgreSql` – these have also been fixed. There was also test case in `PostgreSqlTest` that was seemingly copied over from `MySqlTest`, in that it included a reference to the credentials text file – this has been corrected as well.