### PR TITLE
[ Fix ] Method return type hints in abstract DbDumper

### DIFF
--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -143,7 +143,7 @@ class MySql extends DbDumper
         $this->checkIfDumpWasSuccessFul($process, $dumpFile);
     }
 
-    public function addExtraOption(string $extraOption): self
+    public function addExtraOption(string $extraOption): static
     {
         if (str_contains($extraOption, '--all-databases')) {
             $this->dbNameWasSetAsExtraOption = true;

--- a/src/DbDumper.php
+++ b/src/DbDumper.php
@@ -47,7 +47,7 @@ abstract class DbDumper
         return $this->dbName;
     }
 
-    public function setDbName(string $dbName): self
+    public function setDbName(string $dbName): static
     {
         $this->dbName = $dbName;
 
@@ -59,7 +59,7 @@ abstract class DbDumper
         return $this->databaseUrl;
     }
 
-    public function setDatabaseUrl(string $databaseUrl): self
+    public function setDatabaseUrl(string $databaseUrl): static
     {
         $this->databaseUrl = $databaseUrl;
 
@@ -68,21 +68,21 @@ abstract class DbDumper
         return $this;
     }
 
-    public function setUserName(string $userName): self
+    public function setUserName(string $userName): static
     {
         $this->userName = $userName;
 
         return $this;
     }
 
-    public function setPassword(string $password): self
+    public function setPassword(string $password): static
     {
         $this->password = $password;
 
         return $this;
     }
 
-    public function setHost(string $host): self
+    public function setHost(string $host): static
     {
         $this->host = $host;
 
@@ -94,28 +94,28 @@ abstract class DbDumper
         return $this->host;
     }
 
-    public function setPort(int $port): self
+    public function setPort(int $port): static
     {
         $this->port = $port;
 
         return $this;
     }
 
-    public function setSocket(string $socket): self
+    public function setSocket(string $socket): static
     {
         $this->socket = $socket;
 
         return $this;
     }
 
-    public function setTimeout(int $timeout): self
+    public function setTimeout(int $timeout): static
     {
         $this->timeout = $timeout;
 
         return $this;
     }
 
-    public function setDumpBinaryPath(string $dumpBinaryPath): self
+    public function setDumpBinaryPath(string $dumpBinaryPath): static
     {
         if ($dumpBinaryPath !== '' && ! str_ends_with($dumpBinaryPath, '/')) {
             $dumpBinaryPath .= '/';
@@ -131,14 +131,14 @@ abstract class DbDumper
         return $this->compressor->useExtension();
     }
 
-    public function useCompressor(Compressor $compressor): self
+    public function useCompressor(Compressor $compressor): static
     {
         $this->compressor = $compressor;
 
         return $this;
     }
 
-    public function includeTables(string | array $includeTables): self
+    public function includeTables(string | array $includeTables): static
     {
         if (! empty($this->excludeTables)) {
             throw CannotSetParameter::conflictingParameters('includeTables', 'excludeTables');
@@ -153,7 +153,7 @@ abstract class DbDumper
         return $this;
     }
 
-    public function excludeTables(string | array $excludeTables): self
+    public function excludeTables(string | array $excludeTables): static
     {
         if (! empty($this->includeTables)) {
             throw CannotSetParameter::conflictingParameters('excludeTables', 'includeTables');
@@ -168,7 +168,7 @@ abstract class DbDumper
         return $this;
     }
 
-    public function addExtraOption(string $extraOption): self
+    public function addExtraOption(string $extraOption): static
     {
         if (! empty($extraOption)) {
             $this->extraOptions[] = $extraOption;
@@ -177,7 +177,7 @@ abstract class DbDumper
         return $this;
     }
 
-    public function addExtraOptionAfterDbName(string $extraOptionAfterDbName): self
+    public function addExtraOptionAfterDbName(string $extraOptionAfterDbName): static
     {
         if (! empty($extraOptionAfterDbName)) {
             $this->extraOptionsAfterDbName[] = $extraOptionAfterDbName;


### PR DESCRIPTION
In the `abstract class` `DbDumper` we have several methods that return `$this` with a return type of `self`. While this works just fine at execution, it provides incorrect feedback when running static analysis.

Take the following example:
```
MySql::create()
            ->setDbName($database['database'])
            ->setUserName($database['username'])
            ->setPassword($database['password'])
            ->setHost($database['host'])
            ->doNotUseColumnStatistics()
            ->addExtraOption('--no-data')
            ->addExtraOption('--set-gtid-purged=OFF')
            ->addExtraOption('--default-character-set=utf8mb4')
            ->dumpToFile(public_path('db/mysql-schema.dump'));
```

The first four method calls here exist on the `DbDumper` class, but the return type only expects an implementation of DbDumper. This means that while this will function just fine in production, the expected type is now unaware of the `doNotUseColumnStatistics()` method on the `MySql` class.

Since the DbDumper class is abstract and cannot therefor be instantiated on it's own anyways, having the return types of any functions returning `$this` changed from `self` to `static`, static analyzers can now correctly track down the chained methods on the instantiated instance in which we're operating.