### PR TITLE
Turn off gtid comments

### DIFF
--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -26,7 +26,7 @@ class MySql extends DbDumper
 
     protected bool $allDatabasesWasSetAsExtraOption = false;
 
-    protected string $setGtidPurged = 'AUTO';
+    protected string $setGtidPurged = 'OFF';
 
     protected bool $createTables = true;
 


### PR DESCRIPTION
Hi there,

Without this being turned off, it's causing an error during database restore process.

More [here](https://stackoverflow.com/questions/44015692/access-denied-you-need-at-least-one-of-the-super-privileges-for-this-operat).

If this (as a base repo) is not the place for this change, maybe we can add it via `setGtidPurged()` method in the laravel-backup repo here: https://github.com/spatie/laravel-backup/blob/main/src/Tasks/Backup/DbDumperFactory.php#L48