### PR TITLE
[3.x] Ensure port is a string when creating credentials file for Postgres

### DIFF
--- a/src/Databases/PostgreSql.php
+++ b/src/Databases/PostgreSql.php
@@ -79,7 +79,7 @@ class PostgreSql extends DbDumper
     {
         $contents = [
             $this->escapeCredentialEntry($this->host),
-            $this->escapeCredentialEntry($this->port),
+            $this->escapeCredentialEntry((string) $this->port),
             $this->escapeCredentialEntry($this->dbName),
             $this->escapeCredentialEntry($this->userName),
             $this->escapeCredentialEntry($this->password),


### PR DESCRIPTION
This PR ensures that the port is a string when creating the credentials file contents when using Postgres.

In strict mode, since `port` is an int, an error occurs when you try to dump a database:

```

   TypeError

  str_replace(): Argument #3 ($subject) must be of type array|string, int given

  at vendor/spatie/db-dumper/src/Databases/PostgreSql.php:95
     91▕     }
     92▕
     93▕     protected function escapeCredentialEntry($entry): string
     94▕     {
  ➜  95▕         $entry = str_replace('\\', '\\\\', $entry);
     96▕         $entry = str_replace(':', '\\:', $entry);
     97▕
     98▕         return $entry;
     99▕     }

      +5 vendor frames

  6   [internal]:0
      Spatie\Backup\Tasks\Backup\BackupJob::Spatie\Backup\Tasks\Backup\{closure}(Object(Spatie\DbDumper\Databases\PostgreSql), "pgsql")
      +19 vendor frames

  26  artisan:35
      Illuminate\Foundation\Console\Kernel::handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
```

For MySQL this isn't happening since the port gets coerced into a string through string interpolation.

By casting the port into a string, the error goes away.