### PR TITLE
Allow set dump binary path with empty value

### DIFF
--- a/src/DbDumper.php
+++ b/src/DbDumper.php
@@ -115,7 +115,7 @@ abstract class DbDumper
         return $this;
     }
 
-    public function setDumpBinaryPath(string $dumpBinaryPath): self
+    public function setDumpBinaryPath(string $dumpBinaryPath = ''): self
     {
         if ($dumpBinaryPath !== '' && ! str_ends_with($dumpBinaryPath, '/')) {
             $dumpBinaryPath .= '/';


### PR DESCRIPTION
Currently if no value gets passed to the `setDumpBinaryPath` because of different environment variables, you get this:

```
production.ERROR: Too few arguments to function Spatie\DbDumper\DbDumper::setDumpBinaryPath(), 0 passed
```

But this makes it possible to have a custom path in some environments, and set it back to default which is already an empty string when no parameters are passed.