### PR TITLE
feat: :tada: Add Feature to Skip AUTO_INCREMENT Values in MySQL Dumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ For compressing dump files, `gzip` and/or `bzip2` should be installed.
 ## Installation
 
 You can install the package via composer:
-``` bash
+
+```bash
 composer require spatie/db-dumper
 ```
 
@@ -120,6 +121,36 @@ Spatie\DbDumper\Databases\MySql::create()
     ->dumpToFile('dump.sql');
 ```
 
+### Handling AUTO_INCREMENT Values in Dumps
+
+When creating a database dump, you might need to control the inclusion of AUTO_INCREMENT values. This can be crucial for avoiding primary key conflicts or for maintaining ID consistency when transferring data across environments.
+
+#### Skipping AUTO_INCREMENT Values
+
+To omit the AUTO_INCREMENT values from the tables in your dump, use the skipAutoIncrement method. This is particularly useful to prevent conflicts when importing the dump into another database where those specific AUTO_INCREMENT values might already exist, or when the exact values are not relevant.
+
+```php
+Spatie\DbDumper\Databases\MySql::create()
+    ->setDbName('dbname')
+    ->setUserName('username')
+    ->setPassword('password')
+    ->skipAutoIncrement()
+    ->dumpToFile('dump.sql');
+```
+
+### Including AUTO_INCREMENT values in the dump
+
+By default, the AUTO_INCREMENT values are included in the dump. However, if you previously used the skipAutoIncrement method and wish to ensure that the AUTO_INCREMENT values are included in a subsequent dump, use the dontSkipAutoIncrement method to explicitly include them.
+
+```php
+Spatie\DbDumper\Databases\MySql::create()
+    ->setDbName('dbname')
+    ->setUserName('username')
+    ->setPassword('password')
+    ->dontSkipAutoIncrement()
+    ->dumpToFile('dump.sql');
+```
+
 ### Use a Database URL
 
 In some applications or environments, database credentials are provided as URLs instead of individual components. In this case, you can use the `setDatabaseUrl` method instead of the individual methods.
@@ -146,6 +177,7 @@ Spatie\DbDumper\Databases\MySql::create()
     ->includeTables(['table1', 'table2', 'table3'])
     ->dumpToFile('dump.sql');
 ```
+
 Using a string:
 
 ```php
@@ -185,6 +217,7 @@ Spatie\DbDumper\Databases\MySql::create()
     ->excludeTables(['table1', 'table2', 'table3'])
     ->dumpToFile('dump.sql');
 ```
+
 Using a string:
 
 ```php
@@ -197,6 +230,7 @@ Spatie\DbDumper\Databases\MySql::create()
 ```
 
 ### Do not write CREATE TABLE statements that create each dumped table.
+
 ```php
 $dumpCommand = MySql::create()
     ->setDbName('dbname')
@@ -207,6 +241,7 @@ $dumpCommand = MySql::create()
 ```
 
 ### Adding extra options
+
 If you want to add an arbitrary option to the dump command you can use `addExtraOption`
 
 ```php
@@ -247,8 +282,8 @@ If you want the output file to be compressed, you can use a compressor class.
 
 There are two compressors that come out of the box:
 
-- `GzipCompressor` - This will compress your db dump with `gzip`. Make sure `gzip` is installed on your system before using this.
-- `Bzip2Compressor` - This will compress your db dump with `bzip2`. Make sure `bzip2` is installed on your system before using this.
+-   `GzipCompressor` - This will compress your db dump with `gzip`. Make sure `gzip` is installed on your system before using this.
+-   `Bzip2Compressor` - This will compress your db dump with `bzip2`. Make sure `bzip2` is installed on your system before using this.
 
 ```php
 $dumpCommand = MySql::create()
@@ -295,7 +330,7 @@ class GzipCompressor implements Compressor
 
 ## Testing
 
-``` bash
+```bash
 $ composer test
 ```
 
@@ -313,8 +348,8 @@ Please review [our security policy](../../security/policy) on how to report secu
 
 ## Credits
 
-- [Freek Van der Herten](https://github.com/freekmurze)
-- [All Contributors](../../contributors)
+-   [Freek Van der Herten](https://github.com/freekmurze)
+-   [All Contributors](../../contributors)
 
 Initial PostgreSQL support was contributed by [Adriano Machado](https://github.com/ammachado). SQlite support was contributed by [Peter Matseykanets](https://twitter.com/pmatseykanets).
 

--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -28,6 +28,8 @@ class MySql extends DbDumper
 
     protected string $setGtidPurged = 'AUTO';
 
+    protected bool $skipAutoIncrement = false;
+
     protected bool $createTables = true;
 
     /** @var false|resource */
@@ -126,6 +128,18 @@ class MySql extends DbDumper
     {
         $this->setGtidPurged = $setGtidPurged;
 
+        return $this;
+    }
+
+    public function skipAutoIncrement(): self
+    {
+        $this->skipAutoIncrement = true;
+        return $this;
+    }
+
+    public function dontSkipAutoIncrement(): self
+    {
+        $this->skipAutoIncrement = false;
         return $this;
     }
 
@@ -233,7 +247,15 @@ class MySql extends DbDumper
             $command[] = $extraOptionAfterDbName;
         }
 
-        return $this->echoToFile(implode(' ', $command), $dumpFile);
+        $finalDumpCommand = implode(' ', $command);
+
+        if ($this->skipAutoIncrement) {
+            $sedCommand = "sed 's/ AUTO_INCREMENT=[0-9]*\b//'";
+            $finalDumpCommand .= " | {$sedCommand}";
+        }
+
+        return $this->echoToFile($finalDumpCommand, $dumpFile);
+
     }
 
     public function getContentsOfCredentialsFile(): string

--- a/tests/MySqlTest.php
+++ b/tests/MySqlTest.php
@@ -204,6 +204,28 @@ it('can generate a dump command for specific tables as array', function () {
     );
 });
 
+it('can generate a dump command skipping auto increment values', function () {
+    $dumpCommand = MySql::create()
+        ->setDbName('dbname')
+        ->setUserName('username')
+        ->setPassword('password')
+        ->skipAutoIncrement()
+        ->getDumpCommand('dump.sql', 'credentials.txt');
+
+    expect($dumpCommand)->toContain("sed 's/ AUTO_INCREMENT=[0-9]*\\b//'");
+});
+
+it('can generate a dump command not skipping auto increment values', function () {
+    $dumpCommand = MySql::create()
+        ->setDbName('dbname')
+        ->setUserName('username')
+        ->setPassword('password')
+        ->dontSkipAutoIncrement()
+        ->getDumpCommand('dump.sql', 'credentials.txt');
+
+    expect($dumpCommand)->not->toContain("sed 's/ AUTO_INCREMENT=[0-9]*\\b//'");
+});
+
 it('can generate a dump command for specific tables as string', function () {
     $dumpCommand = MySql::create()
         ->setDbName('dbname')


### PR DESCRIPTION
This pull request introduces a new feature to the MySql dumper class, enabling users to exclude AUTO_INCREMENT values from their MySQL dumps. By adding a skipAutoIncrement boolean property along with two methods, skipAutoIncrement() and dontSkipAutoIncrement(), users can now toggle whether AUTO_INCREMENT values are included in the dump files. This flexibility is useful in scenarios where preserving AUTO_INCREMENT values is not necessary, such as when managing schema migrations or version controlling database structures.

Implementation Details:

A protected boolean property $skipAutoIncrement has been added to control whether AUTO_INCREMENT values are included in the dump.
The skipAutoIncrement() method sets $skipAutoIncrement to true, instructing the dumper to exclude AUTO_INCREMENT values from the output.
Conversely, the dontSkipAutoIncrement() method sets $skipAutoIncrement to false, including AUTO_INCREMENT values in the dump.
Within the getDumpCommand method, a conditional check on $skipAutoIncrement appends a sed command (sed 's/ AUTO_INCREMENT=[0-9]*\b//') to the mysqldump command. This sed command effectively removes any AUTO_INCREMENT declarations from the dump output.

Usage Example:

config/database.php

```php
'dump' => [
     'skipAutoIncrement' => true,
     // or
     'dontSkipAutoIncrement' => true,
],
```