### PR TITLE
add doNotDumpData() for MySQL and Postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Spatie\DbDumper\Databases\MySql::create()
 
 ### Excluding tables from the dump
 
-Using an array:
+You can exclude tables from the dump by using an array:
 
 ```php
 Spatie\DbDumper\Databases\MySql::create()
@@ -218,7 +218,7 @@ Spatie\DbDumper\Databases\MySql::create()
     ->dumpToFile('dump.sql');
 ```
 
-Using a string:
+Or by using a string:
 
 ```php
 Spatie\DbDumper\Databases\MySql::create()
@@ -229,7 +229,9 @@ Spatie\DbDumper\Databases\MySql::create()
     ->dumpToFile('dump.sql');
 ```
 
-### Do not write CREATE TABLE statements that create each dumped table.
+### Do not write CREATE TABLE statements that create each dumped table
+
+You can use `doNotCreateTables` to prevent writing create statements.
 
 ```php
 $dumpCommand = MySql::create()
@@ -240,7 +242,10 @@ $dumpCommand = MySql::create()
     ->getDumpCommand('dump.sql', 'credentials.txt');
 ```
 
-### Do not write row data.
+### Do not write row data
+
+You can use `doNotDumpData` to prevent writing row data.
+
 
 ```php
 $dumpCommand = MySql::create()

--- a/README.md
+++ b/README.md
@@ -240,6 +240,17 @@ $dumpCommand = MySql::create()
     ->getDumpCommand('dump.sql', 'credentials.txt');
 ```
 
+### Do not write row data.
+
+```php
+$dumpCommand = MySql::create()
+    ->setDbName('dbname')
+    ->setUserName('username')
+    ->setPassword('password')
+    ->doNotDumpData()
+    ->getDumpCommand('dump.sql', 'credentials.txt');
+```
+
 ### Adding extra options
 
 If you want to add an arbitrary option to the dump command you can use `addExtraOption`

--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -32,6 +32,8 @@ class MySql extends DbDumper
 
     protected bool $createTables = true;
 
+    protected bool $includeData = true;
+
     /** @var false|resource */
     private $tempFileHandle;
 
@@ -181,6 +183,13 @@ class MySql extends DbDumper
         return $this;
     }
 
+    public function doNotDumpData(): self
+    {
+        $this->includeData = false;
+
+        return $this;
+    }
+
     public function getDumpCommand(string $dumpFile, string $temporaryCredentialsFile): string
     {
         $quote = $this->determineQuote();
@@ -192,6 +201,10 @@ class MySql extends DbDumper
 
         if (! $this->createTables) {
             $command[] = '--no-create-info';
+        }
+
+        if (!$this->includeData) {
+            $command[] = '--no-data';
         }
 
         if ($this->skipComments) {

--- a/src/Databases/PostgreSql.php
+++ b/src/Databases/PostgreSql.php
@@ -12,6 +12,8 @@ class PostgreSql extends DbDumper
 
     protected bool $createTables = true;
 
+    protected bool $includeData = true;
+
     /** @var false|resource */
     private $tempFileHandle;
 
@@ -58,6 +60,10 @@ class PostgreSql extends DbDumper
 
         if (! $this->createTables) {
             $command[] = '--data-only';
+        }
+
+        if (!$this->includeData) {
+            $command[] = '--schema-only';
         }
 
         foreach ($this->extraOptions as $extraOption) {
@@ -116,6 +122,13 @@ class PostgreSql extends DbDumper
     public function doNotCreateTables(): self
     {
         $this->createTables = false;
+
+        return $this;
+    }
+
+    public function doNotDumpData(): self
+    {
+        $this->includeData = false;
 
         return $this;
     }

--- a/tests/MySqlTest.php
+++ b/tests/MySqlTest.php
@@ -448,3 +448,17 @@ it('can generate a dump command with no create info', function () {
         '\'mysqldump\' --defaults-extra-file="credentials.txt" --no-create-info --skip-comments --extended-insert dbname > "dump.sql"'
     );
 });
+
+
+it('can generate a dump command with no data', function () {
+    $dumpCommand = MySQL::create()
+        ->setDbName('dbname')
+        ->setUserName('username')
+        ->setPassword('password')
+        ->doNotDumpData()
+        ->getDumpCommand('dump.sql', 'credentials.txt');
+
+    expect($dumpCommand)->toEqual(
+        '\'mysqldump\' --defaults-extra-file="credentials.txt" --no-data --skip-comments --extended-insert dbname > "dump.sql"'
+    );
+});

--- a/tests/PostgreSqlTest.php
+++ b/tests/PostgreSqlTest.php
@@ -231,3 +231,14 @@ it('can generate a dump command with no create info', function () {
 
     expect($dumpCommand)->toEqual('\'pg_dump\' -U "username" -h localhost -p 5432 --data-only > "dump.sql"');
 });
+
+it('can generate a dump command with no data', function () {
+    $dumpCommand = PostgreSql::create()
+        ->setDbName('dbname')
+        ->setUserName('username')
+        ->setPassword('password')
+        ->doNotDumpData()
+        ->getDumpCommand('dump.sql');
+
+    expect($dumpCommand)->toEqual('\'pg_dump\' -U "username" -h localhost -p 5432 --schema-only > "dump.sql"');
+});


### PR DESCRIPTION
I have added the ability to not dump data for both MySQL and Postgres.

This option is useful to get a schema only database backup.

Tests for the new methods ```MySql::doNotDumpData()``` and ```PostgreSql::doNotDumpData()``` are also added. All unit tests are green.