### PR TITLE
Add append mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,21 @@ $dumpCommand = MySql::create()
     ->getDumpCommand('dump.sql', 'credentials.txt');
 ```
 
+### Append instead of overwriting a dump file
+
+You can use `useAppendMode` with MySQL to append to the file instead of overwriting it. 
+This is useful for two-step dumps when you want to dump the whole schema but only some of the data 
+(for example: only migrations, or only product but not customer data).
+
+```php
+$dumpCommand = MySql::create()
+    ->setDbName('dbname')
+    ->setUserName('username')
+    ->setPassword('password')
+    ->useAppendMode()
+    ->getDumpCommand('dump.sql', 'credentials.txt');
+```
+
 ### Adding extra options
 
 If you want to add an arbitrary option to the dump command you can use `addExtraOption`

--- a/src/Databases/MySql.php
+++ b/src/Databases/MySql.php
@@ -3,6 +3,7 @@
 namespace Spatie\DbDumper\Databases;
 
 use Spatie\DbDumper\DbDumper;
+use Spatie\DbDumper\Exceptions\CannotSetParameter;
 use Spatie\DbDumper\Exceptions\CannotStartDump;
 use Symfony\Component\Process\Process;
 
@@ -195,6 +196,17 @@ class MySql extends DbDumper
     public function doNotDumpData(): self
     {
         $this->includeData = false;
+
+        return $this;
+    }
+
+    public function useAppendMode(): self
+    {
+        if($this->compressor) {
+            throw CannotSetParameter::conflictingParameters('append mode', 'compress');
+        }
+
+        $this->appendMode = true;
 
         return $this;
     }

--- a/src/DbDumper.php
+++ b/src/DbDumper.php
@@ -35,6 +35,8 @@ abstract class DbDumper
 
     protected array $extraOptionsAfterDbName = [];
 
+    protected bool $appendMode = false;
+
     protected ?object $compressor = null;
 
     public static function create(): static
@@ -133,6 +135,10 @@ abstract class DbDumper
 
     public function useCompressor(Compressor $compressor): self
     {
+        if($this->appendMode) {
+            throw CannotSetParameter::conflictingParameters('compressor', 'append mode');
+        }
+
         $this->compressor = $compressor;
 
         return $this;
@@ -245,6 +251,10 @@ abstract class DbDumper
 
         if ($this->compressor) {
             return $this->getCompressCommand($command, $dumpFile);
+        }
+
+        if($this->appendMode) {
+            return $command . ' >> ' . $dumpFile;
         }
 
         return $command . ' > ' . $dumpFile;

--- a/tests/MySqlTest.php
+++ b/tests/MySqlTest.php
@@ -462,3 +462,53 @@ it('can generate a dump command with no data', function () {
         '\'mysqldump\' --defaults-extra-file="credentials.txt" --no-data --skip-comments --extended-insert dbname > "dump.sql"'
     );
 });
+
+// We already implicitly test that by default append mode is off, with the expected command strings in the other tests
+it('can be set to use append mode', function(){
+    $dumpCommand = MySql::create()
+        ->setDbName('dbname')
+        ->setUserName('username')
+        ->setPassword('password')
+        ->useAppendMode()
+        ->getDumpCommand('dump.sql', 'credentials.txt');
+
+    expect($dumpCommand)->toEqual(
+        '\'mysqldump\' --defaults-extra-file="credentials.txt" --skip-comments --extended-insert dbname >> "dump.sql"'
+    );
+});
+
+it('will throw an exception when using Bzip2Compressor-mode while GzipCompressor is already used.', function () {
+    MySql::create()
+        ->setDbName('dbname')
+        ->setUserName('username')
+        ->setPassword('password')
+        ->useCompressor(new Bzip2Compressor())
+        ->useAppendMode();
+})->throws(CannotSetParameter::class);
+
+it('will throw an exception when using Bzip2Compressor while append-mode is already used.', function () {
+    MySql::create()
+        ->setDbName('dbname')
+        ->setUserName('username')
+        ->setPassword('password')
+        ->useAppendMode()
+        ->useCompressor(new Bzip2Compressor());
+})->throws(CannotSetParameter::class);
+
+it('will throw an exception when using append-mode while GzipCompressor is already used.', function () {
+    MySql::create()
+        ->setDbName('dbname')
+        ->setUserName('username')
+        ->setPassword('password')
+        ->useCompressor(new GzipCompressor())
+        ->useAppendMode();
+})->throws(CannotSetParameter::class);
+
+it('will throw an exception when using GzipCompressor while append-mode is already used.', function () {
+    MySql::create()
+        ->setDbName('dbname')
+        ->setUserName('username')
+        ->setPassword('password')
+        ->useAppendMode()
+        ->useCompressor(new GzipCompressor());
+})->throws(CannotSetParameter::class);


### PR DESCRIPTION
This PR adds the possibility of appending (using >> ) instead of overwriting ( > ) when dumping a MySQL DB to a file.

This is useful when doing a two-step dump, where in the first step you dump the whole schema, and in the second step you dump the contents of only _some_ tables. For example:

* Dump a copy of a production database for a webshop, keeping product data but stripping customer data.
* Dump a copy of a database where you only keep the migrations table.

For an extended example of that functionality, see https://github.com/netz98/n98-magerun/wiki/Stripped-Database-Dumps ; I've implemented it myself in https://github.com/LBannenberg/laravel-mysqldump

I was able to do it myself ( https://github.com/LBannenberg/laravel-mysqldump ) by extending \Spatie\DbDumper\Databases\MySql , but with this PR that would not be needed anymore, especially now that https://github.com/spatie/db-dumper/pull/208 made the doNotDumpData() command available.

Because I'm not sure if this functionality also makes sense for other DBs than MySQL I only added the method to set the flag in \Spatie\DbDumper\Databases\MySql, but the flag is used in the main \Spatie\DbDumper\DbDumper class. This seemed preferable to copying the echoToFile command to \Spatie\DbDumper\Databases\MySql .

I added an exception when trying to combine append-mode with compressors because I don't expect that behavior to be compatible.