### PR TITLE
Fix grammar in DumpFailed exception message

### DIFF
--- a/src/Exceptions/DumpFailed.php
+++ b/src/Exceptions/DumpFailed.php
@@ -11,7 +11,7 @@ class DumpFailed extends Exception
     {
         $processOutput = static::formatProcessOutput($process);
 
-        return new self("The dump process failed with a none successful exitcode.{$processOutput}");
+        return new self("The dump process failed with a non-successful exit code.{$processOutput}");
     }
 
     public static function dumpfileWasNotCreated(Process $process): self


### PR DESCRIPTION
Hi! Small grammatical cleanup in the message thrown by `DumpFailed::processDidNotEndSuccessfully()`.

**Before:** `The dump process failed with a none successful exitcode.`
**After:**  `The dump process failed with a non-successful exit code.`

Two corrections:
- "none successful" → "non-successful"
- "exitcode" → "exit code"

This message surfaces in logs whenever a dump process exits non-zero, so the cleanup makes log output read a bit more naturally. No behavior change.